### PR TITLE
Add icon hover effects

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -151,6 +151,12 @@ input {
 .web-activity-icon {
 	background-repeat: no-repeat;	
 	background-position: center;
+	padding: 2px;
+}
+
+.web-activity-icon:hover {
+	background-color: #d5d5d5;
+	border-radius: 5px;
 }
 
 .web-activity-disable {


### PR DESCRIPTION
In Sugar, when we hover over activity icons there is a hover effect that is applied to them. This is not present in Sugarizer, and I think it should be added.
It gives the user a sense of where he is moving his cursor and where he can click to start an activity.