### PR TITLE
Maze Activity, display a score

### DIFF
--- a/activities/MazeWeb.activity/js/activity.js
+++ b/activities/MazeWeb.activity/js/activity.js
@@ -40,6 +40,11 @@ define(function (require) {
 
         var gameSize = 60;
 
+        var scoreP1 = 0;
+        var scoreP2 = 0;
+        var scoreP3 = 0;
+        var scoreP4 = 0;
+
         var levelStatus;
         var levelTransitionRadius;
         var levelStartingValue;
@@ -57,7 +62,7 @@ define(function (require) {
             canvasHeight = window.innerHeight - toolbarElem.offsetHeight - 3;
 
             cellWidth = Math.floor(canvasWidth / maze.width);
-            cellHeight = Math.floor(canvasHeight / maze.height);
+            cellHeight = Math.floor((canvasHeight - 50) / maze.height);
 
             mazeCanvas.width = canvasWidth;
             mazeCanvas.height = canvasHeight;
@@ -66,10 +71,26 @@ define(function (require) {
             spriteCanvas.height = cellHeight * controlNames.length;
         };
 
+        var updateScore = function () {
+            var mazeCtx = mazeCanvas.getContext("2d");
+            mazeCtx.fillStyle = "white";
+            mazeCtx.font = "35px Arial";
+            mazeCtx.fillText(scoreP1.toString(), 3*(mazeCanvas.width/28)+50, 27*(mazeCanvas.height/28)-15);
+            mazeCtx.fillText(scoreP2.toString(), 10*(mazeCanvas.width/28)+50, 27*(mazeCanvas.height/28)-15);
+            mazeCtx.fillText(scoreP3.toString(), 17*(mazeCanvas.width/28)+50, 27*(mazeCanvas.height/28)-15);
+            mazeCtx.fillText(scoreP4.toString(), 24*(mazeCanvas.width/28)+50, 27*(mazeCanvas.height/28)-15);
+            mazeCtx.font = "20px Arial";
+            mazeCtx.fillText("Player-1 :", 3*(mazeCanvas.width/28)-40, 27*(mazeCanvas.height/28)-16);
+            mazeCtx.fillText("Player-2 :", 10*(mazeCanvas.width/28)-40, 27*(mazeCanvas.height/28)-16);
+            mazeCtx.fillText("Player-3 :", 17*(mazeCanvas.width/28)-40, 27*(mazeCanvas.height/28)-16);
+            mazeCtx.fillText("Player-4 :", 24*(mazeCanvas.width/28)-40, 27*(mazeCanvas.height/28)-16);
+        };
+
         var onWindowResize = function () {
             updateMazeSize();
             updateSprites();
             drawMaze();
+            updateScore();
         };
         window.addEventListener('resize', onWindowResize);
 
@@ -279,7 +300,9 @@ define(function (require) {
                 levelStartingValue = undefined;
                 levelStatus = 'playing';
                 drawMaze();
+                updateScore();
             });
+            updateScore();
             tween.start();
         }
 
@@ -295,6 +318,16 @@ define(function (require) {
 
         var onLevelComplete = function (player) {
             winner = player;
+
+            if (winner["control"] == "arrows")
+                scoreP1 += 1;
+            else if(winner["control"] == "wasd")
+                scoreP2 += 1;
+            else if(winner["control"] == "ijkl")
+                scoreP3 += 1;
+            else if(winner["control"] == "mouse")
+                scoreP4 += 1;
+
             levelStatus = 'transition';
 
             var audio = new Audio('sounds/win'+soundType);


### PR DESCRIPTION
When I was using the maze activity, I could not keep track of the number of levels I completed, so I thought adding a score would make it easier for the users to know how many levels they have completed.
A total of 4 scores will be displayed, one for each player.

![screenshot from 2016-04-20 19 54 33](https://cloud.githubusercontent.com/assets/9864149/14678023/bc55a546-0731-11e6-8e1a-c286642c8ecb.png)
