### PR TITLE
Removal of the www folder before git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ Then create a directory for Sugarizer Cordova and put the content of the git rep
 	cordova create sugar-cordova
 	cd sugar-cordova
 	rm config.xml
+	rm -fr www
 	git clone https://github.com/llaske/sugarizer.git www
 
 Add the platform you want to add (here Android) and all cordova plugin need:


### PR DESCRIPTION
Added removal of the www folder before fetching the sugarizer repository, otherwise the git clone is showing an error output like :  "fatal: le chemin de destination 'www' existe déjà et n'est pas un répertoire vide." since the directory exists already