### PR TITLE
Feature/docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,32 @@ Sugarizer Server features include:
 * Backup and shared storage for Client and Thin Client,
 * Presence and collaboration handling between Client/Thin Client on the same network
 
-To run your own Sugarizer Server, follow the step behind. Commands are shown from a new Debian Linux machine and could be different for other platforms or for an already installed machine:
+##Running the server using Docker
+
+To run your own Sugarizer Server with a single command line using Docker and Docker Compose:
+
+**Install Docker and Docker Compose on Ubuntu**
+
+	  curl -fsSL https://get.docker.com/ | sh
+
+Install Docker Compose
+
+	curl -L "https://github.com/docker/compose/releases/download/1.8.1/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose
+	  chmod +x /usr/local/bin/docker-compose
+
+You can find more details about the installation of **Docker** here : https://docker.github.io/engine/installation/
+
+You can	find more details about	the installation of **Docker Compose** here : https://docs.docker.com/compose/install/
+
+After that, go to the sugarizer folder and launch
+
+      docker-compose up -d
+
+Your Sugarizer server will start automatically and will be accessible on http://127.0.0.1 and your public IP. The database will be persisted inside the folder docker/db
+
+##Running the server using the classic way
+
+To run your own Sugarizer Server **without Docker**, follow the step behind. Commands are shown from a new Debian Linux machine and could be different for other platforms or for an already installed machine:
 
 **Install Apache2**: you need to install Apache2 and ensure than few mods are available and enabled: mod_headers, mod_proxy, mod_proxy_http and mode_rewrite. You need also to allow override on /var/www directory. See [here](http://httpd.apache.org/docs/ "here") for more.
 
@@ -390,6 +415,7 @@ To run unit tests for Sugarizer Client, run "file:///var/www/sugarizer/test/inde
 
 # Supervise the server
 
+This is not needed with Docker Compose
 Instead of running your Sugarizer Server like described in the "Run MongoDB and Sugarizer Server" section above, you could use a tool like [supervisor](http://supervisord.org/) to run it in background.
 
 First install, supervisor:

--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ Install Docker Compose
 	curl -L "https://github.com/docker/compose/releases/download/1.8.1/docker-compose-$(uname -s)-$(uname -m)" > /usr/local/bin/docker-compose
 	  chmod +x /usr/local/bin/docker-compose
 
-You can find more details about the installation of **Docker** here : https://docker.github.io/engine/installation/
+You can find more details about the installation of **Docker** [here](https://docker.github.io/engine/installation/)
 
-You can	find more details about	the installation of **Docker Compose** here : https://docs.docker.com/compose/install/
+You can	find more details about	the installation of **Docker Compose** [here](https://docs.docker.com/compose/install/)
 
 After that, go to the sugarizer folder and launch
 
@@ -153,7 +153,8 @@ You could also run unit tests (see below) to ensure that everything works.
 
 **Server settings** 
 
-If need, Sugarizer server settings could be changed using the [server/sugarizer.ini](server/sugarizer.ini) config file.
+If needed, Sugarizer server settings could be changed using the [sugarizer.ini](server/sugarizer.ini) config file (you could use another name for this file: just pass the new name 
+as [sugarizer.js](server/sugarizer.js) parameter).
 
 	[web]
 	port = 8080

--- a/README.md
+++ b/README.md
@@ -415,7 +415,8 @@ To run unit tests for Sugarizer Client, run "file:///var/www/sugarizer/test/inde
 
 # Supervise the server
 
-This is not needed with Docker Compose
+This is not needed with Docker Compose.
+
 Instead of running your Sugarizer Server like described in the "Run MongoDB and Sugarizer Server" section above, you could use a tool like [supervisor](http://supervisord.org/) to run it in background.
 
 First install, supervisor:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "2"
+
+services:
+  mongodb:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile-mongodb
+    restart: always
+    volumes:
+      - ./docker/db:/data/db
+    environment:
+      - AUTH=no
+
+  server:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile-server
+    restart: always
+    volumes:
+      - ./:/sugarizer-repo
+    links:
+      - mongodb
+    ports:
+      - 8039:8039
+
+  http:
+    build:
+      context: ./docker
+      dockerfile: Dockerfile-http
+    restart: always
+    volumes:
+      - ./:/sugarizer-repo
+    ports:
+      - 80:80
+    links:
+      - server

--- a/docker/Dockerfile-http
+++ b/docker/Dockerfile-http
@@ -1,0 +1,3 @@
+FROM nginx:alpine
+WORKDIR /sugarizer-repo
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/docker/Dockerfile-mongodb
+++ b/docker/Dockerfile-mongodb
@@ -1,0 +1,3 @@
+FROM mongo:3.3
+
+CMD mongod

--- a/docker/Dockerfile-server
+++ b/docker/Dockerfile-server
@@ -1,0 +1,10 @@
+FROM node:5.7.1-slim
+RUN mkdir -p /opt
+ADD https://yarnpkg.com/latest.tar.gz /opt/latest.tar.gz
+WORKDIR /opt
+RUN tar zxvf /opt/latest.tar.gz
+RUN mv /opt/dist /opt/yarn
+ENV PATH "$PATH:/opt/yarn/bin"
+
+WORKDIR /sugarizer-repo/server
+CMD yarn install; node /sugarizer-repo/server/sugarizer.js /sugarizer-repo/docker/sugarizer-docker.ini

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,33 @@
+worker_processes 5;
+events {
+    worker_connections 1024;
+}
+
+http {
+  include  mime.types;
+  index    index.html index.htm index.php;
+  default_type application/octet-stream;
+  sendfile     on;
+    
+
+  gzip on;
+  proxy_connect_timeout 3000;
+  proxy_send_timeout 3000;
+  proxy_read_timeout 3000;
+  send_timeout 3000;
+  client_max_body_size 250M;
+
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header Host $http_host;
+      
+  server {
+      listen 80;
+      root /sugarizer-repo;
+
+      location /api/ {
+        rewrite ^/api(.*) $1 break;     
+        proxy_pass http://server:8080;
+      }
+  }
+}

--- a/docker/sugarizer-docker.ini
+++ b/docker/sugarizer-docker.ini
@@ -1,0 +1,23 @@
+; Sugarizer configuration file
+
+[web]
+port = 8080
+
+[database]
+server = mongodb
+port = 27017
+name = sugarizer
+
+[presence]
+port = 8039
+
+[collections]
+users = users
+journal = journal
+
+[activities]
+activities_directory_name = activities
+activities_path = ../activities
+template_directory_name = ActivityTemplate
+activity_info_path = activity/activity.info
+favorites = org.sugarlabs.GearsActivity,org.sugarlabs.MazeWebActivity,org.olpcfrance.PaintActivity,org.olpcfrance.TamTamMicro,org.olpcfrance.MemorizeActivity,org.olpg-france.physicsjs,org.sugarlabs.CalculateActivity,org.sugarlabs.TurtleBlocksJS,org.sugarlabs.Clock,org.sugarlabs.SpeakActivity,org.sugarlabs.moon,org.olpcfrance.RecordActivity,org.olpcfrance.Abecedarium,org.olpcfrance.videoviewer,org.olpcfrance.FoodChain,org.olpc-france.labyrinthjs,org.olpcfrance.TankOp,org.sugarlabs.ChatPrototype,org.olpcfrance.Gridpaint,org.olpc-france.LOLActivity,org.olpcfrance.sharednotes,org.sugarlabs.StopwatchActivity,org.sugarlabs.GTDActivity,org.sugarlabs.Markdown,org.laptop.WelcomeWebActivity

--- a/server/settings.js
+++ b/server/settings.js
@@ -1,11 +1,15 @@
 // Load Sugarizer Settings
 
 var	fs = require('fs'),
-	ini = require('ini');
+ini = require('ini');
 
 // Load and parse sugarizer.ini file
 exports.load = function(callback) {
-	fs.readFile("sugarizer.ini", 'utf-8', function(err, content) {
+	var confFile = "sugarizer.ini"
+	if (process.argv.length >= 3) {
+		confFile = process.argv[2];
+	}
+	fs.readFile(confFile, 'utf-8', function(err, content) {
 		if (err) throw err;
 		callback(ini.parse(content));
 	});


### PR DESCRIPTION
Added a way to launch Sugarizer using Docker/Docker-Compose

The goal is to provide a way to launch Sugarizer with one command
`docker-compose up -d`

The server and the database are automatically configured by the docker-compose.yml and the docker images inside the docker folder.
At launch docker-compose will build the images and launch the containers with restart:always policy to remove the need of supervisor
The database is persisted in the docker/db folder

- Updated the Readme
How to install docker/docker-compose and launch the app

- Sugarizer server is able to load another .ini file if provided.
node sugarizer.js => will use default file
node sugarizer.js test.ini => will use test.ini