### PR TITLE
A few small CSS changes to the search bar

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -103,11 +103,12 @@ input {
 	background-repeat: no-repeat;
 	background-position: center;
 	background-size: 20px 20px;
-	top: 5px;
-	left: 2px;
+	left: 6px;
 	width: 20px;
 	height: 20px;
 	display: inline-block;
+	top: 50%;
+	transform: translateY(-50%);
 }
 
 .search-field-iconcancel {
@@ -115,18 +116,18 @@ input {
 	background-image: url(../icons/entry-cancel.svg);
 	background-repeat: no-repeat;
 	background-position: center;
-	top: 5px;
 	right: 10px;
 	background-size: 20px 20px;
 	width: 20px;
 	height: 20px;
 	display: inline-block;
+	top: 50%;
+	transform: translateY(-50%);
 }
 
 .search-field-input {
 	opacity: 1;
 	margin-left: 30px;
-	margin-top: 5px;
 	border: 0px;
 	display: inline-block;
 	background-color: #e5e5e5;
@@ -134,6 +135,9 @@ input {
 	line-height: 22px;
 	outline: 0;
 	font-size: 10pt;
+	position: relative;
+	top: 50%;
+	transform: translateY(-50%);
 }
 
 .search-field-input:focus {


### PR DESCRIPTION
While using Sugarizer I couldn't help but notice that the icons for the magnifying glass and cancel button were slightly out of alignment. I edited the CSS to increase the margin to the left of the magnifying glass from 5px to 6px, and to vertically center the magnifying glass, input text and cancel button in the search bar. This was done by removing the absolute top/left positions and replacing it with a percentage-based `top: 50%;`. However, this centers the top of the element meaning that the middle of the element is off-centre; to compensate for this I added `transform: translateY(-50%);` which would translate the element up by 50% of its height thus centering it vertically.