### PR TITLE
Enabled clicking on abacus beads to move it #146

### DIFF
--- a/activities/Abacus.activity/js/abacusbead.js
+++ b/activities/Abacus.activity/js/abacusbead.js
@@ -84,24 +84,16 @@ function AbacusBead(x,y,blockcol,abacus,column,i,value,beadheight){
 			this.resetAge();
 		}
 	}
-
+	
 	this.addClickListeners = function(){
 		var th = this;
 		var col = column;
-		this.bead.on("mousedown", function(evt) {
-		    th.originaly = evt.stageY;
+		this.bead.addEventListener("click", function(evt){
+			col.shuntLeft(th.index);
 		});
-
-		this.bead.on("pressup", function(evt) {
-		    if (th.originaly<evt.stageY){
-		    	//moved down
-		    	console.log("down");
-		    	col.shuntRight(th.index);
-		    } else if (th.originaly>evt.stageY){
-		    	console.log("up");
-		    	col.shuntLeft(th.index);
-		    }
-		});
+		this.bead.addEventListener("dblclick", function(evt){
+			col.shuntRight(th.index);
+		});		
 	}
 
 	this.updateValue = function(on,positive){

--- a/activities/Abacus.activity/js/abacusbead.js
+++ b/activities/Abacus.activity/js/abacusbead.js
@@ -94,6 +94,9 @@ function AbacusBead(x,y,blockcol,abacus,column,i,value,beadheight){
 		this.bead.addEventListener("dblclick", function(evt){
 			col.shuntRight(th.index);
 		});		
+		this.bead.addEventListener("touchstart", function(evt){
+			col.shuntRight(th.index);
+		});
 	}
 
 	this.updateValue = function(on,positive){


### PR DESCRIPTION
Earlier, the user had to drag the beads, now a single click sends the beads up and double-clicking on them brings them down.
![peek 2018-01-15 20-54](https://user-images.githubusercontent.com/23054160/34949623-9d96b236-fa36-11e7-969d-3eb3a2f9c9f0.gif)

