### PR TITLE
fix: dropdown containing all activities fixed 

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -290,6 +290,8 @@ body {
 	border-style: none solid solid solid;
 	border-width: 2px;
 	z-index: 1;
+	height: 80vh;
+	overflow: scroll;
 }
 
 .popup-footer :hover{

--- a/css/styles.css
+++ b/css/styles.css
@@ -290,7 +290,7 @@ body {
 	border-style: none solid solid solid;
 	border-width: 2px;
 	z-index: 1;
-	height: 80vh;
+	max-height: 80vh;
 	overflow: scroll;
 }
 


### PR DESCRIPTION
#152 dropdown containing all activity names now doesn't overflow the screen instead is scrollable.

<img width="1440" alt="screen shot 2018-02-11 at 2 26 47 pm" src="https://user-images.githubusercontent.com/25136650/36071741-8b5eb57e-0f39-11e8-88db-d98ea44c8bac.png">
