### PR TITLE
Abacus does not display solution with big numbers #140 

### DIFF
--- a/activities/Abacus.activity/js/onecolumnabacus.js
+++ b/activities/Abacus.activity/js/onecolumnabacus.js
@@ -330,6 +330,8 @@ function OneColumnAbacus(stage,rods,number,base,colours,startvalue,schety,fracti
 			}
 			if((this.answertext.text).length >= 40) {
 				this.answertext.font =  parseInt(((this.blockWidth / (this.answertext.text).length)*40)) + "px Arial";
+			} else {
+				this.answertext.font =  (this.blockWidth).toString()+"px Arial";
 			}
 		}
 	}
@@ -372,6 +374,8 @@ function OneColumnAbacus(stage,rods,number,base,colours,startvalue,schety,fracti
 			}
 			if((this.answertext.text).length >= 40) {
 				this.answertext.font =  parseInt(((this.blockWidth / (this.answertext.text).length)*40)) + "px Arial";
+			} else {
+				this.answertext.font =  (this.blockWidth).toString()+"px Arial";
 			}
 		}
 		

--- a/activities/Abacus.activity/js/onecolumnabacus.js
+++ b/activities/Abacus.activity/js/onecolumnabacus.js
@@ -328,6 +328,9 @@ function OneColumnAbacus(stage,rods,number,base,colours,startvalue,schety,fracti
 			} else {
 				this.answertext.text = "";
 			}
+			if((this.answertext.text).length >= 40) {
+				this.answertext.font =  parseInt(((this.blockWidth / (this.answertext.text).length)*40)) + "px Arial";
+			}
 		}
 	}
 
@@ -367,7 +370,11 @@ function OneColumnAbacus(stage,rods,number,base,colours,startvalue,schety,fracti
 			} else {
 				this.answertext.text = "";
 			}
+			if((this.answertext.text).length >= 40) {
+				this.answertext.font =  parseInt(((this.blockWidth / (this.answertext.text).length)*40)) + "px Arial";
+			}
 		}
+		
 	}
 
 	this.init = function(){

--- a/activities/Abacus.activity/js/standardabacus.js
+++ b/activities/Abacus.activity/js/standardabacus.js
@@ -260,6 +260,8 @@ function StandardAbacus(stage,rods,topnumber,factor,bottomnumber,base,colours,st
 			}
 			if((this.answertext.text).length >= 40) {
 				this.answertext.font =  parseInt(((this.blockWidth / (this.answertext.text).length)*40)) + "px Arial";
+			} else {
+				this.answertext.font =  (this.blockWidth).toString()+"px Arial";
 			}
 		}
 	}

--- a/activities/Abacus.activity/js/standardabacus.js
+++ b/activities/Abacus.activity/js/standardabacus.js
@@ -258,6 +258,9 @@ function StandardAbacus(stage,rods,topnumber,factor,bottomnumber,base,colours,st
 			} else {
 				this.answertext.text = "";
 			}
+			if((this.answertext.text).length >= 40) {
+				this.answertext.font =  parseInt(((this.blockWidth / (this.answertext.text).length)*40)) + "px Arial";
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #140 
The text now dynamically changes size according to the available canvas space and the length of the sum. I thought this solution was best.
Example:
![demo](https://i.imgur.com/sb9F3Fx.gif)

Let me know if you want me to try another solution.