### PR TITLE
Add an history of last QR Code generated/read in QR Code activity 

### DIFF
--- a/activities/QRCode.activity/css/activity.css
+++ b/activities/QRCode.activity/css/activity.css
@@ -142,3 +142,31 @@
 	visibility: hidden;
 	z-index: 4;
 }
+#qrtextdropdown {
+	width: 89.7vw;
+	height: 60px;
+	border-radius: 22px;
+	padding-left: 2vh;
+	margin-left: 3vh;
+	-webkit-appearance: button;
+	-moz-appearance: button;
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	background-color: #e5e5e5;
+	background-image: url(../icons/go-down.svg);
+	background-position: 100% 40%;
+	background-repeat: no-repeat;
+	border-radius: 22px 22px 0px 0px;
+	box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.1);
+	color: #555;
+	font-size: inherit;
+	overflow: hidden;
+	padding-top: 2px;
+	padding-bottom: 2px;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+	font-size: 20px;
+}
+#qrtextdropdown option {
+	font-size: 20px;
+}

--- a/activities/QRCode.activity/css/activity.css
+++ b/activities/QRCode.activity/css/activity.css
@@ -143,21 +143,17 @@
 	z-index: 4;
 }
 #qrtextdropdown {
-	width: 89.7vw;
-	height: 60px;
-	border-radius: 22px;
-	padding-left: 2vh;
-	margin-left: 3vh;
+	height: 7vh;
+	width: 7vh;
 	-webkit-appearance: button;
 	-moz-appearance: button;
 	-webkit-user-select: none;
 	-moz-user-select: none;
-	background-color: #e5e5e5;
+	background: none;
+	border: none;
 	background-image: url(../icons/go-down.svg);
-	background-position: 100% 40%;
-	background-repeat: no-repeat;
-	border-radius: 22px 22px 0px 0px;
-	box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.1);
+	background-size: 55px 50px;
+	background-position: 50% 50%;
 	color: #555;
 	font-size: inherit;
 	overflow: hidden;
@@ -165,7 +161,15 @@
 	padding-bottom: 2px;
 	text-overflow: ellipsis;
 	white-space: nowrap;
-	font-size: 20px;
+	font-size: 0;
+	height: 45px;
+	width: 50px;
+	margin: 8px;
+	right: 60px;
+	bottom: 15px;
+	top: 2px;
+	z-index: 1;
+	position: absolute;
 }
 #qrtextdropdown option {
 	font-size: 20px;

--- a/activities/QRCode.activity/css/activity.css
+++ b/activities/QRCode.activity/css/activity.css
@@ -37,7 +37,7 @@
 	height: 40px;
 	margin: 5px;
 	margin-left: 6vw;
-	width: 89vw;
+	width: 85vw;
 	font-size: 28pt;
 	font-weight: bold;
 	z-index:0;
@@ -45,6 +45,11 @@
 @media (max-width: 960px) {
 	#user-text {
 		margin-left: 10vw;
+	}
+}
+@media (max-width: 600px) {
+	#user-text {
+		margin-left: 20vw;
 	}
 }
 
@@ -176,9 +181,9 @@
 	z-index: 1;
 	position: absolute;
 }
-@media (min-width: 960px) {
+@media (min-width: 1140px) {
 	#qrtextdropdown {
-		margin-left: 2.5vw;
+		margin-left: 1.5vw;
 	}
 }
 #qrtextdropdown option {

--- a/activities/QRCode.activity/css/activity.css
+++ b/activities/QRCode.activity/css/activity.css
@@ -36,11 +36,16 @@
 #user-text {
 	height: 40px;
 	margin: 5px;
-	margin-left: 3vh;
+	margin-left: 6vw;
 	width: 89vw;
 	font-size: 28pt;
 	font-weight: bold;
 	z-index:0;
+}
+@media (max-width: 960px) {
+	#user-text {
+		margin-left: 10vw;
+	}
 }
 
 .text-url {
@@ -165,11 +170,16 @@
 	height: 45px;
 	width: 50px;
 	margin: 8px;
-	right: 60px;
+	left: -0.4vw;
 	bottom: 15px;
 	top: 2px;
 	z-index: 1;
 	position: absolute;
+}
+@media (min-width: 960px) {
+	#qrtextdropdown {
+		margin-left: 2.5vw;
+	}
 }
 #qrtextdropdown option {
 	font-size: 20px;

--- a/activities/QRCode.activity/icons/go-down.svg
+++ b/activities/QRCode.activity/icons/go-down.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   enable-background="new 0 0 55.125 55"
+   height="55px"
+   version="1.1"
+   viewBox="0 0 55.125 55"
+   width="55.125px"
+   x="0px"
+   xml:space="preserve"
+   y="0px"
+   id="svg2"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="go-down.svg"><metadata
+   id="metadata10"><rdf:RDF><cc:Work
+       rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+         rdf:resource="http://purl.org/dc/dcmitype/StillImage" /></cc:Work></rdf:RDF></metadata><defs
+   id="defs8" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="1920"
+   inkscape:window-height="1017"
+   id="namedview6"
+   showgrid="false"
+   inkscape:zoom="4.2909091"
+   inkscape:cx="3.092161"
+   inkscape:cy="27.5"
+   inkscape:window-x="-8"
+   inkscape:window-y="81"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="layer5" />
+   <g
+   inkscape:groupmode="layer"
+   id="layer5"
+   inkscape:label="Layer 3" /><g
+   inkscape:groupmode="layer"
+   id="layer4"
+   inkscape:label="Layer 2" /><g
+   display="block"
+   id="go-right"
+   style="display:block;fill:#666666"
+   transform="rotate(90,27.5,27.5)">
+	<g
+   display="inline"
+   id="g5"
+   style="display:inline;fill:#666666">
+		<path
+   d="M 50,27.5 C 50,15.073 39.927,5 27.5,5 15.072,5 5,15.073 5,27.5 5,39.927 15.072,50 27.5,50 39.927,50 50,39.927 50,27.5 Z M 22.725,37.907 c -0.624,-0.626 -0.939,-1.447 -0.939,-2.271 0,-0.822 0.315,-1.646 0.939,-2.271 l 5.833,-5.84 -5.802,-5.657 c -0.645,-0.63 -0.967,-1.464 -0.967,-2.3 0,-0.808 0.305,-1.62 0.914,-2.246 1.238,-1.266 3.271,-1.295 4.546,-0.056 l 8.126,7.929 c 0,0.002 0,0.002 0,0.003 0.011,0.01 0.021,0.015 0.028,0.022 0.115,0.116 0.208,0.245 0.302,0.371 0.028,0.039 0.064,0.071 0.093,0.111 0.075,0.114 0.133,0.24 0.194,0.36 0.035,0.068 0.078,0.131 0.107,0.2 0.039,0.1 0.064,0.203 0.093,0.306 0.032,0.099 0.068,0.191 0.09,0.292 0.018,0.083 0.018,0.169 0.028,0.251 0.015,0.122 0.033,0.244 0.036,0.366 0,0.071 -0.014,0.147 -0.021,0.219 -0.007,0.133 -0.011,0.266 -0.036,0.395 -0.014,0.075 -0.043,0.146 -0.064,0.223 -0.035,0.123 -0.061,0.251 -0.111,0.373 -0.032,0.082 -0.082,0.161 -0.121,0.244 -0.055,0.105 -0.104,0.215 -0.165,0.315 -0.058,0.085 -0.13,0.159 -0.194,0.239 -0.064,0.086 -0.122,0.176 -0.201,0.254 -0.003,0.006 -0.011,0.01 -0.014,0.013 -0.004,0.007 -0.008,0.011 -0.011,0.015 l -8.13,8.142 c -1.259,1.254 -3.292,1.257 -4.553,-0.002 z"
+   id="path7"
+   style="fill:#666666"
+   inkscape:connector-curvature="0" />
+	</g>
+</g><g
+   inkscape:groupmode="layer"
+   id="layer3"
+   inkscape:label="Layer 1" /></svg>

--- a/activities/QRCode.activity/index.html
+++ b/activities/QRCode.activity/index.html
@@ -55,6 +55,10 @@
 	<div id="input-box">
 		<input id="user-text" name="userText" type="text"></input>
 		<button id="generate-button" class="toolbutton" title="Generate"></button>
+		<br>
+		<select id="qrtextdropdown">
+			<option value="default">----</option>
+		</select>
 		<hr>
 	</div>
 	<div id="outdiv">

--- a/activities/QRCode.activity/index.html
+++ b/activities/QRCode.activity/index.html
@@ -54,11 +54,11 @@
 <div id="canvas">
 	<div id="input-box">
 		<input id="user-text" name="userText" type="text"></input>
+		<select id="qrtextdropdown">
+				<option value="default">----</option>
+			</select>
 		<button id="generate-button" class="toolbutton" title="Generate"></button>
 		<br>
-		<select id="qrtextdropdown">
-			<option value="default">----</option>
-		</select>
 		<hr>
 	</div>
 	<div id="outdiv">

--- a/activities/QRCode.activity/index.html
+++ b/activities/QRCode.activity/index.html
@@ -53,10 +53,9 @@
 <!-- The content of your activity goes inside the canvas -->
 <div id="canvas">
 	<div id="input-box">
+			<select id="qrtextdropdown">
+				</select>
 		<input id="user-text" name="userText" type="text"></input>
-		<select id="qrtextdropdown">
-				<option value="default">----</option>
-			</select>
 		<button id="generate-button" class="toolbutton" title="Generate"></button>
 		<br>
 		<hr>

--- a/activities/QRCode.activity/js/activity.js
+++ b/activities/QRCode.activity/js/activity.js
@@ -216,7 +216,7 @@ define(["sugar-web/activity/activity","sugar-web/datastore", "sugar-web/env", "w
 
 		// Update dropdown with user history
 		function updateHistory() {
-			var mhtml = '<option value="default">----</option>';
+			var mhtml = '';
 			var index = history.length;
 			while(index--) {
 				mhtml += '<option value="'+(history[index])+'">'+(history[index])+'</option>';


### PR DESCRIPTION
Fixes #244
This PR implements the functionality to restore previously generated barcodes. See below:
Choose QR's with dropdown:
![demo](https://i.imgur.com/e6CYfuq.gif)
QR's being saved to datastore:
![demo](https://i.imgur.com/uifEDZs.gif)
