### PR TITLE
Fix issue of vanishing recent marks

### DIFF
--- a/activities/Stopwatch.activity/js/activity.js
+++ b/activities/Stopwatch.activity/js/activity.js
@@ -126,6 +126,9 @@ define(["sugar-web/activity/activity","mustache", "sugar-web/env"], function (ac
         };
 
         Stopwatch.prototype.onMarkClicked = function () {
+            if (this.marks.length >= 10) {
+                this.marks.shift();
+            }
             this.marks.push(pad(this.minutes) + ':' + pad(this.seconds) + ':' +
                             pad(this.tenthsOfSecond));
             this.updateMarks();


### PR DESCRIPTION
#280 
Implemented a simple fix by keeping the 10 most recent of the lap times.