### PR TITLE
Tutorial documentation update

### DIFF
--- a/docs/tutorial_step4.md
+++ b/docs/tutorial_step4.md
@@ -58,26 +58,24 @@ First we will slightly refactor (i.e. improve) our `activity/activity.js` file. 
 		document.getElementById("user").innerHTML = "<h1>"+currentenv.user.name+" played !</h1>";
 	});
 
-We will refactor it to store pawns in an array `pawns` and to add a new method `drawPawn` to draw all icons at one time. So instead of adding a new `div` element on each button click, we just add a new element in the `pawns` array and we call the `drawPawn` icon to redraw the board. Here is the resulting code:
+We will refactor it to store pawns in an array `pawns` and to add a new method `drawPawn` to draw one icon on the board. So on each button click, we add a new element in the `pawns` array and we call the `drawPawn` icon to draw one icon at a time on the board. Here is the resulting code:
 
 	// Draw pawns
 	var pawns = [];
-	var drawPawns = function() {
-		document.getElementById("pawns").innerHTML = '';
-		for (var i = 0 ; i < pawns.length ; i++) {
-			var pawn = document.createElement("div");
-			pawn.className = "pawn";
 
-			document.getElementById("pawns").appendChild(pawn);
-			icon.colorize(pawn, pawns[i]);
-		}
+	var drawPawn = function(color) {
+		var pawn = document.createElement("div");
+		pawn.className = "pawn";
+
+		document.getElementById("pawns").appendChild(pawn);
+		icon.colorize(pawn, color);
 	}
 
 	// Handle click on add
 	document.getElementById("add-button").addEventListener('click', function (event) {
 
 		pawns.push(currentenv.user.colorvalue);
-		drawPawns();
+		drawPawn(currentenv.user.colorvalue);
 
 		document.getElementById("user").innerHTML = "<h1>"+currentenv.user.name+" played !</h1>";
 	});
@@ -174,8 +172,14 @@ In the same way that the `setAsText`/`save` methods, the datastore object provid
 		}
 	});
 
-We load the string - in the data parameter -, we parse it to an object and we set it in our `pawns` array. That's all for the initialization but we need also to draw it, so here is the full source code to write in `activity/activity.js`:
+We load the string - in the data parameter -, we parse it to an object and we set it in our `pawns` array. That's all for the initialization but we need also to draw it and to draw all icons at one time we add a new method `drawPawns`, so here is the full source code to write in `activity/activity.js`:
 
+	var drawPawns = function() {
+		document.getElementById("pawns").innerHTML = '';
+		for (var i = 0 ; i < pawns.length ; i++) {
+			drawPawn(pawns[i]);
+		}
+	}
 
 	// Load from datastore
 	if (!environment.objectId) {

--- a/docs/tutorial_step6.md
+++ b/docs/tutorial_step6.md
@@ -167,7 +167,7 @@ Now that our activity is shared, we have to slightly update the Plus button list
 	document.getElementById("add-button").addEventListener('click', function (event) {
 
 		pawns.push(currentenv.user.colorvalue);
-		drawPawns();
+		drawPawn(currentenv.user.colorvalue);
 
 		document.getElementById("user").innerHTML = "<h1>"+webL10n.get("Played", {name:currentenv.user.name})+"</h1>";
 
@@ -213,11 +213,11 @@ The `onNetworkDataReceived` callback is the same one we used previously. So it's
 			return;
 		}
 		pawns.push(msg.content);
-		drawPawns();
+		drawPawn(msg.content);
 		document.getElementById("user").innerHTML = "<h1>"+webL10n.get("Played", {name:msg.user.name})+"</h1>";
 	}; 
 
-This callback is call each time a message is received from the server. The message is the parameter for the callback. We first test the `networkId` in this message to ignore message that we sent ourself. Then we add the message `content` (i.e. colors for the user sending the message) to our `pawns` array and redraw the board with the `drawPawns()` call. Finally we update the welcome message to give the player's name.
+This callback is call each time a message is received from the server. The message is the parameter for the callback. We first test the `networkId` in this message to ignore message that we sent ourself. Then we add the message `content` (i.e. colors for the user sending the message) to our `pawns` array and add a pawn on the board with the `drawPawn()` call. Finally we update the welcome message to give the player's name.
 
 Let's try if everything works. From the Michaël browser, launch a new Pawn activity and share it with the network menu.
 
@@ -307,7 +307,7 @@ Then we need to update the `onNetworkDataReceived` callback to handle the new me
 				break;
 			case 'update':
 				pawns.push(msg.content.data);
-				drawPawns();
+				drawPawn(msg.content.data);
 				document.getElementById("user").innerHTML = "<h1>"+webL10n.get("Played", {name:msg.user.name})+"</h1>";
 				break;
 		}


### PR DESCRIPTION
I was going through the Pawn Activity tutorial. I found out that on adding every new pawn, whole `pawns` div is being re-rendered.
Suppose if you're adding N pawns one at a time, then the pawn div gets reset N times and a new pawn div is added N! (N factorial) times. It has a significantly higher time complexity than adding one pawn at a time which has a time complexity proportional to N.
When neighbor connects, I've kept in mind to clear the canvas and draw all the pawns in one go.

I have made appropriate changes in the documentation, keeping it simple.
I'm open to suggestions if you find any issue with my implementation.