### PR TITLE
#292: Languages in "Language settings" should be non-translated.

### DIFF
--- a/js/dialog.js
+++ b/js/dialog.js
@@ -580,16 +580,16 @@ enyo.kind({
 		this.$.message.setContent(l10n.get("ChooseLanguage"));
 		this.initlanguage = this.currentlanguage = preferences.getLanguage();
 		this.languageset = [
-			{code: "en", icon: null, name: l10n.get("English")},
-			{code: "es", icon: null, name: l10n.get("Spanish")},
-			{code: "fr", icon: null, name: l10n.get("French")},
-			{code: "de", icon: null, name: l10n.get("German")},
-			{code: "pt", icon: null, name: l10n.get("Portuguese")},
-			{code: "ar", icon: null, name: l10n.get("Arabic")},
-			{code: "ja", icon: null, name: l10n.get("Japanese")},
-			{code: "pl", icon: null, name: l10n.get("Polish")},
-			{code: "ibo", icon: null, name: l10n.get("Igbo")},
-			{code: "yor", icon: null, name: l10n.get("Yoruba")}
+			{code: "en", icon: null, name: "English (" + l10n.get("English") +")"},
+			{code: "es", icon: null, name: "Español (" + l10n.get("Spanish") +")"},
+			{code: "fr", icon: null, name: "Français (" + l10n.get("French") +")"},
+			{code: "de", icon: null, name: "Deutsch (" + l10n.get("German") +")"},
+			{code: "pt", icon: null, name: "Português (" + l10n.get("Portuguese") +")"},
+			{code: "ar", icon: null, name: "عربي (" + l10n.get("Arabic") +")"},
+			{code: "ja", icon: null, name: "日本語 (" + l10n.get("Japanese") +")"},
+			{code: "pl", icon: null, name: "Polski (" + l10n.get("Polish") +")"},
+			{code: "ibo", icon: null, name: "Igbo (" + l10n.get("Igbo") +")"},
+			{code: "yor", icon: null, name: "Yoruba (" + l10n.get("Yoruba") +")"}
 		];
 		this.$.languageselect.setItems(this.languageset);
 		for (var i = 0 ; i < this.languageset.length ; i++) {


### PR DESCRIPTION
Languages list in User settings->Language settings should
be non-translated to local-browser language.
Fixes issue #292 
Now:
If local language is English:
![image](https://user-images.githubusercontent.com/25907420/54202610-6e055e80-44f6-11e9-8d55-63c76afcbc52.png)

If local language is French:
![image](https://user-images.githubusercontent.com/25907420/54202648-84131f00-44f6-11e9-9870-b705cb9dacae.png)

In `()` it shows language name translated to local language and without `()` it shows original language name without being translated to any other language. 

This is my first contribution, so please let me know your feedback. 