### PR TITLE
audio bar display added for media viewer

### DIFF
--- a/activities/MediaViewer.activity/js/activity.js
+++ b/activities/MediaViewer.activity/js/activity.js
@@ -51,7 +51,6 @@ function displayAudio(data) {
     audio.src = data;
     audio.setAttribute("controls", "");
 
-    audio.style.height = "auto";
     audio.style.maxWidth = document.body.clientWidth - 55 + "px";
     audio.style.width = document.body.clientWidth - 60 + "px";
     audio.style.marginTop = (document.body.clientHeight - 55 - audio.getBoundingClientRect().height) / 2 + "px"


### PR DESCRIPTION
Fixes #312 
Currently, if a user tries to play an audio(.wav) file from the journal media activity viewer starts, but the audio bar is not displayed. This PR solves the issue:

Before:

![before_audio](https://user-images.githubusercontent.com/34412933/54884385-4323ee80-4e96-11e9-905f-e796d5406d04.png)

After: 


![after_audio](https://user-images.githubusercontent.com/34412933/54884387-4919cf80-4e96-11e9-8758-5f6695eeb1a2.png)
