### PR TITLE
QR code History case sensitive

### DIFF
--- a/activities/QRCode.activity/js/activity.js
+++ b/activities/QRCode.activity/js/activity.js
@@ -38,7 +38,6 @@ define(["sugar-web/activity/activity","sugar-web/datastore", "sugar-web/env", "w
 		var generateCode = function(text) {
 			qrCode.clear();
 			qrCode.makeCode(text);
-			var text = userText.value.toLowerCase();
 			if (text.indexOf("http://") == 0 || text.indexOf("https://") == 0) {
 				document.getElementById("user-text").classList.add("text-url");
 			} else {

--- a/activities/QRCode.activity/js/activity.js
+++ b/activities/QRCode.activity/js/activity.js
@@ -38,12 +38,13 @@ define(["sugar-web/activity/activity","sugar-web/datastore", "sugar-web/env", "w
 		var generateCode = function(text) {
 			qrCode.clear();
 			qrCode.makeCode(text);
+			addToHistory(text);
+			var text = userText.value.toLowerCase();
 			if (text.indexOf("http://") == 0 || text.indexOf("https://") == 0) {
 				document.getElementById("user-text").classList.add("text-url");
 			} else {
 				document.getElementById("user-text").classList.remove("text-url");
 			}
-			addToHistory(text);
 		}
 
 		// Process Resize events


### PR DESCRIPTION
This pr solves the issue mentioned [here](https://github.com/llaske/sugarizer/pull/317#issuecomment-478325854)
Earlier the history content was case insensitive but QR code were case sensitive . In this PR history is also made case sensitive 
Current:
![current](https://user-images.githubusercontent.com/30404493/55851758-b5275380-5b77-11e9-9c31-a7d105bd09cd.gif)
Expected:
![expected](https://user-images.githubusercontent.com/30404493/55851767-bb1d3480-5b77-11e9-810f-05b4500f2a4e.gif)
