### PR TITLE
adding a palette for changing grid size( fixes #381)

### DIFF
--- a/activities/GameOfLife.activity/css/activity.css
+++ b/activities/GameOfLife.activity/css/activity.css
@@ -12,6 +12,10 @@
   background-image: url(../icons/gen-speed.svg);
 }
 
+#main-toolbar #size-button {
+  background-image: url(../icons/grid-size.svg);
+}
+
 #main-toolbar #random {
   background-image: url(../icons/random.svg);
 }

--- a/activities/GameOfLife.activity/icons/grid-size.svg
+++ b/activities/GameOfLife.activity/icons/grid-size.svg
@@ -2,18 +2,7 @@
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
+<!-- This work is a derivative( different stroke and fill) of <a rel="license" href="https://www.svgrepo.com/svg/10605/square-boxes-of-increasing-size">svgrepo'square boxes of increasing size </a> licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>. -->
 
 <g class="currentLayer" style=""><title>Layer 1</title><g id="svg_1" class="selected" fill="#ffffff" fill-opacity="1">
 	<g id="svg_2" fill="#ffffff" fill-opacity="1">

--- a/activities/GameOfLife.activity/icons/grid-size.svg
+++ b/activities/GameOfLife.activity/icons/grid-size.svg
@@ -1,0 +1,39 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="78.58200073242188" height="78.58200073242188" style="" xml:space="preserve"><rect id="backgroundrect" width="100%" height="100%" x="0" y="0" fill="none" stroke="none"/>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<g class="currentLayer" style=""><title>Layer 1</title><g id="svg_1" class="selected" fill="#ffffff" fill-opacity="1">
+	<g id="svg_2" fill="#ffffff" fill-opacity="1">
+		<rect x="24.453266143798828" y="26.593633844827774" width="51.05181121826172" height="41.158960149312854" id="svg_3" fill="#ffffff" fill-opacity="1"/>
+		<polygon points="46.57633590698242,18.610291043839652 13.160604476928711,18.610291043839652 13.160604476928711,45.550699485026826 21.099624633789062,45.550699485026826 21.099624633789062,24.971968151894316 46.57633590698242,24.971968151894316 " id="svg_4" fill="#ffffff" fill-opacity="1"/>
+		<polygon points="35.97983169555664,9.803770829255654 2.5641045570373535,9.803770829255654 2.5641045570373535,36.74418298648425 10.50126838684082,36.74418298648425 10.50126838684082,16.16544979533103 35.97983169555664,16.16544979533103 " id="svg_5" fill="#ffffff" fill-opacity="1"/>
+	</g>
+</g><g id="svg_6">
+</g><g id="svg_7">
+</g><g id="svg_8">
+</g><g id="svg_9">
+</g><g id="svg_10">
+</g><g id="svg_11">
+</g><g id="svg_12">
+</g><g id="svg_13">
+</g><g id="svg_14">
+</g><g id="svg_15">
+</g><g id="svg_16">
+</g><g id="svg_17">
+</g><g id="svg_18">
+</g><g id="svg_19">
+</g><g id="svg_20">
+</g></g></svg>

--- a/activities/GameOfLife.activity/index.html
+++ b/activities/GameOfLife.activity/index.html
@@ -20,6 +20,7 @@
   <!-- Add more buttons here -->
   <button class="toolbutton" id="play-pause" title="Play/Pause"></button>
 	<button class="toolbutton" id="speed-button" title="Generation Speed"></button>
+	<button class="toolbutton" id="size-button" title="Grid Size"></button>
   <button class="toolbutton" id="random" title="Random"></button>
   <button class="toolbutton" id="glider" title="Glider"></button>
   <button class="toolbutton" id="no" title="No"></button>

--- a/activities/GameOfLife.activity/js/Board.js
+++ b/activities/GameOfLife.activity/js/Board.js
@@ -12,16 +12,16 @@ function Board(boardState, lineColor, deadCellColor, aliveYoungCellColor, aliveO
     });
   };
 
-  this.draw = function () {
-    canvasWidth = (cellWidth + rowPadding) * 50 - 2;
-    canvasHeight = (cellHeight + colPadding) * 30 - 2;
+  this.draw = function (state) {
+    canvasWidth = 1000;
+    canvasHeight = 500;
     canvas.width = canvasWidth;
     canvas.height = canvasHeight;
     canvas.style.background = lineColor;
     canvas.style.boxShadow = '5px 5px 25px 0px rgba(46, 61, 73, 0.2)';
     this.ctx = canvas.getContext('2d');
-    this.cellWidth = cellWidth;
-    this.cellHeight = cellHeight;
+    this.cellWidth = (canvas.width - 2 * state.state.gridCols) / state.state.gridCols;
+    this.cellHeight = (canvas.height - 2 * state.state.gridRows) / state.state.gridRows;
     this.update(boardState);
   };
 
@@ -39,21 +39,18 @@ function Board(boardState, lineColor, deadCellColor, aliveYoungCellColor, aliveO
     });
   };
 
-  this.handleResize = function (windowWidth, state) {
-    var scale = windowWidth / canvasWidth;
+  this.handleResize = function (windowWidth, _state, state) {
+    let scale = windowWidth / canvasWidth;
     if (scale < 1) {
       canvas.width = canvasWidth * (scale - 0.1);
       canvas.height = canvasHeight * (scale - 0.1);
-      this.cellWidth = (canvas.width - 2 * 50) / 50;
-      this.cellHeight = (canvas.height - 2 * 30) / 30;
-      this.update(state);
     } else {
       canvas.width = canvasWidth;
       canvas.height = canvasHeight;
-      this.cellWidth = cellWidth;
-      this.cellHeight = cellHeight;
-      this.update(state);
     }
+    this.cellWidth = (canvas.width - 2 * state.state.gridCols) / state.state.gridCols;
+    this.cellHeight = (canvas.height - 2 * state.state.gridRows) / state.state.gridRows;
+    this.update(_state);
   };
 }
 

--- a/activities/GameOfLife.activity/js/patterns.js
+++ b/activities/GameOfLife.activity/js/patterns.js
@@ -1,19 +1,19 @@
-var initialPattern = function initialPattern() {
-  return new Array(30).fill(0).map(function () {
-    return new Array(50).fill(0);
+var initialPattern = function initialPattern(state) {
+  return new Array(state.state.gridRows).fill(0).map(function () {
+    return new Array(state.state.gridCols).fill(0);
   });
 };
-var generateRandomBoardState = function generateRandomBoardState() {
-  return new Array(30).fill(0).map(function () {
-    var row = new Array(50).fill(0);
+var generateRandomBoardState = function generateRandomBoardState(state) {
+  return new Array(state.state.gridRows).fill(0).map(function () {
+    var row = new Array(state.state.gridCols).fill(0);
     return row.map(function () {
       return Math.floor(Math.random() * 2);
     });
   });
 };
 
-var glider = function glider() {
-  var pattern = initialPattern();
+var glider = function glider(state) {
+  var pattern = initialPattern(state);
   pattern[5][7] = 1;
   pattern[6][5] = 1;
   pattern[6][6] = 1;
@@ -22,11 +22,11 @@ var glider = function glider() {
   return pattern;
 };
 
-var no = function no() {
-  var pattern = initialPattern();
-  for (var j = 0; j < 30; j++) {
+var no = function no(state) {
+  var pattern = initialPattern(state);
+  for (var j = 0; j < state.state.gridRows; j++) {
     if (!((j + 1) % 4 === 0)) {
-      for (var i = 2; i < 50; i += 4) {
+      for (var i = 2; i < state.state.gridCols; i += 4) {
         pattern[j][i] = 1;
       }
     }

--- a/activities/GameOfLife.activity/lib/gridSizePalette.html
+++ b/activities/GameOfLife.activity/lib/gridSizePalette.html
@@ -1,0 +1,3 @@
+<div class="row expand">
+  <span id="sizelabel" style="position:absolute;margin-top:20px;">size:</span><input id="sizevalue" type="range" style="width:70%;margin:3%;margin-left:22%;margin-top:20px;" value=2 min=1 max=6></input>
+</div>

--- a/activities/GameOfLife.activity/lib/gridSizePalette.js
+++ b/activities/GameOfLife.activity/lib/gridSizePalette.js
@@ -1,0 +1,52 @@
+define(["sugar-web/graphics/palette",
+        "text!gridSizePalette.html",'activity/patterns'], function (palette, template, patterns) {
+
+    'use strict';
+
+    var activitypalette = {};
+
+    activitypalette.ActivityPalette = function (activityButton, state, board) {
+
+        palette.Palette.call(this, activityButton);
+
+        var randomPattern = patterns[0];
+        var activityTitle;
+        var descriptionLabel;
+        var descriptionBox;
+
+        this.getPalette().id = "activity-palette";
+
+        var containerElem = document.createElement('div');
+        containerElem.innerHTML = template;
+        this.setContent([containerElem]);
+
+        this.sizeScale = containerElem.querySelector('#sizevalue');
+
+        this.sizeScale.onclick = function(){
+          var val = this.value;
+          var newCols = val*20;
+          var newRows = val*10;
+          state.set({
+            gridCols : newCols,
+            gridRows : newRows,
+            generation : 0
+          });
+          state.set({
+            boardState : randomPattern(state)
+          })
+          board.handleResize(window.innerWidth, state.state.boardState, state);
+        }
+    };
+
+    activitypalette.ActivityPalette.prototype =
+        Object.create(palette.Palette.prototype, {
+            setTitleDescription: {
+                value: "Speed Palette:",
+                enumerable: true,
+                configurable: true,
+                writable: true
+            }
+        });
+
+    return activitypalette;
+});

--- a/activities/GameOfLife.activity/lib/gridSizePalette.js
+++ b/activities/GameOfLife.activity/lib/gridSizePalette.js
@@ -41,7 +41,7 @@ define(["sugar-web/graphics/palette",
     activitypalette.ActivityPalette.prototype =
         Object.create(palette.Palette.prototype, {
             setTitleDescription: {
-                value: "Speed Palette:",
+                value: "Size Palette:",
                 enumerable: true,
                 configurable: true,
                 writable: true

--- a/activities/GameOfLife.activity/locale.ini
+++ b/activities/GameOfLife.activity/locale.ini
@@ -2,19 +2,24 @@
 [*]
 Generation=Generation
 speed=speed :
+size=size :
 
 [en]
 Generation=Generation
 speed=speed :
+size=size :
 
 [es]
 Generation=Generacion
 speed=velocidad :
+size=talla :
 
 [fr]
 Generation=Génération
 speed=vitesse :
+size=taille :
 
 [pt]
 Generation=Geração
 speed=rapidez :
+size=tamanho :


### PR DESCRIPTION
This PR : 
- adds a palette having a slider to change grid size
- adds a code to store the size of a grid in datastore  
- adds localization for size label in the palette
- fixes #381 

![Screenshot from 2019-10-25 22-09-11](https://user-images.githubusercontent.com/40318927/67589289-b4ea5080-f775-11e9-9787-90b31f2a9870.png)

![Screenshot from 2019-10-25 22-09-28](https://user-images.githubusercontent.com/40318927/67589325-c6335d00-f775-11e9-96cd-85421dde6b70.png)
