### PR TITLE
Fixed missing add button and pawns icons

### DIFF
--- a/docs/tutorial_step3.md
+++ b/docs/tutorial_step3.md
@@ -47,7 +47,7 @@ Let's add our new button. It's just a `button` tag with the Sugar-Web `toolbutto
 We will now associate the icon to this new button. This association should be done in the `css/activity.css` file. Add these lines at the end of the file.
 
 	#main-toolbar #add-button {
-		background-image: url(../icons/add.svg);
+		background-image: url(../activity/icons/add.svg);
 	}
 
 Let's run the activity.
@@ -99,7 +99,7 @@ Then just after the `getEnvironment` call, we will add the following event liste
 Make sense? Yes, except that something is missing: the link between the `div` created for the pawn and the pawn icon itself. To do that we have to update the `css/activity.css` file. Add these lines at the end of the file:
 
 	.pawn {
-	  background-image: url(../icons/pawn-icon.svg);
+	  background-image: url(../activity/icons/pawn-icon.svg);
 	  display: inline-block;
 	  width: 65px;
 	  height: 65px;


### PR DESCRIPTION
Fixes #612 

Add button and pawns were invisible due to inappropriate access of image location from directly 'icons/' folder instead of 'activity/icons/' folder. I fixed it in my tutorial code. 