### PR TITLE
[Issue #604 fix] Made the Stopwatch activity responsive

### DIFF
--- a/activities/Stopwatch.activity/css/activity.css
+++ b/activities/Stopwatch.activity/css/activity.css
@@ -39,7 +39,6 @@ ul {
 
 #stopwatch-list li {
   position: relative;
-  padding-bottom: 128px;
   border-bottom: 1px solid black;
 }
 
@@ -47,9 +46,36 @@ ul {
   line-height: 1.2;
 }
 
-.counter, .marks {
-  display: inline-block;
-  transform: translateY(35%);
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.marks-container {
+  width: 50%;
+}
+.buttons-group {
+  margin: 20px;
+}
+.counter-container {
+  margin: 30px;
+}
+
+@media (max-width: 940px) {
+  .row {
+    justify-content: center;
+  }
+  .marks-container {
+    width: 90%;
+  }
+}
+
+.marks-group {
+  display: flex;
+  margin: 30px auto;
+  overflow-x: auto;
+  white-space: nowrap;
 }
 
 .marks {
@@ -62,11 +88,6 @@ ul {
   font-size: 30px;
 }
 
-.buttons-group {
-  display: inline-block;
-  transform: translateY(15%);
-}
-
 .buttons-group button {
   border-radius: 0;
   margin-left: 0;
@@ -74,12 +95,12 @@ ul {
 }
 
 .buttons-group button:first-child {
-  border-radius: 22px 0 0 22px;
+  border-radius: 20px 0 0 20px;
   margin-right: 0;
 }
 
 .buttons-group button:last-child {
-  border-radius: 0 22px 22px 0;
+  border-radius: 0 20px 20px 0;
   margin-left: 0;
 }
 
@@ -111,7 +132,7 @@ button.remove {
 .buttons-group button {
   margin-top: 5.5px;
   height: 66px;
-  width: 66px;
+  width: 55px;
   padding: 0;
   background-position: center;
   background-size: 44px 44px;

--- a/activities/Stopwatch.activity/js/activity.js
+++ b/activities/Stopwatch.activity/js/activity.js
@@ -32,10 +32,10 @@ define(["sugar-web/activity/activity","mustache", "sugar-web/env"], function (ac
             this.template =
                 '<div class="panel-body"></div>' +
                     '<div class="row">' +
-                      '<div class="col-xs-3 col-sm-3 col-md-2 col-lg-2">' +
+                      '<div class="counter-container">' +
                         '<div class="counter">00:00:00</div>' +
                       '</div>' +
-                      '<div class="col-xs-5 col-sm-5 col-md-4 col-lg-3">' +
+                      '<div class="buttons-container">' +
                         '<div class="buttons-group">' +
                             '<button class="start-stop-button start" title="Start"></button>' +
                             '<button class="reset-button" title="Reset"></button>' +
@@ -43,8 +43,10 @@ define(["sugar-web/activity/activity","mustache", "sugar-web/env"], function (ac
                             
                         '</div>' +
                       '</div>' +
-                      '<div class="col-xs-4 col-sm-4 col-md-6 col-lg-7">' +
-                        '<div class="marks"></div>' +
+                      '<div class="marks-container">' +
+                        '<div class="marks-group">' +
+                            '<div class="marks"></div>' +
+                        '</div>' +
                         '<button class="remove" title="Remove"></button>' +
                       '</div>' +
                     '</div>' +
@@ -54,7 +56,9 @@ define(["sugar-web/activity/activity","mustache", "sugar-web/env"], function (ac
 
             this.counterElem = this.elem.querySelector('.counter');
             this.marksElem = this.elem.querySelector('.marks');
+            this.marksGroup = this.elem.querySelector('.marks-group');
             this.running = false;
+            this.firstRun = false;
             this.previousTime = Date.now();
             this.tenthsOfSecond = 0;
             this.seconds = 0;
@@ -97,6 +101,7 @@ define(["sugar-web/activity/activity","mustache", "sugar-web/env"], function (ac
         }
 
         Stopwatch.prototype.onStartStopClicked = function () {
+            this.firstRun = true;
             if (!this.running) {
                 this.running = true;
                 this.tick();
@@ -129,6 +134,9 @@ define(["sugar-web/activity/activity","mustache", "sugar-web/env"], function (ac
         };
 
         Stopwatch.prototype.onMarkClicked = function () {
+            if(!this.firstRun) {
+                return;
+            }
             if (this.marks.length >= 10) {
                 this.marks.shift();
             }
@@ -188,6 +196,7 @@ define(["sugar-web/activity/activity","mustache", "sugar-web/env"], function (ac
                     this.marksElem.innerHTML += ' - ';
                 }
             }
+            this.marksGroup.scrollLeft = this.marksGroup.scrollWidth;
         };
 
         Stopwatch.prototype.updateButtons = function () {


### PR DESCRIPTION
I created a container for the stopwatch marks, which can scroll to accommodate new values. Also fixed some styling to make the design more responsive.
Desktop:
![Annotation 2020-02-24 172256](https://user-images.githubusercontent.com/40134655/75150524-98155800-572a-11ea-8094-fe706903a212.jpg)

Mobile:
![Annotation 2020-02-24 172410](https://user-images.githubusercontent.com/40134655/75150538-a06d9300-572a-11ea-8a66-028c9606ea0d.jpg)
