### PR TITLE
[Issue #665 fix] Fixed overflow of XO Editor on wide screens

### DIFF
--- a/activities/XOEditor.activity/css/activity.css
+++ b/activities/XOEditor.activity/css/activity.css
@@ -29,6 +29,8 @@
 }
 
 #canvas {
+  display: flex;
+  justify-content: center;
   overflow-x: hidden;
   overflow-y: hidden;
 }

--- a/activities/XOEditor.activity/js/activity.js
+++ b/activities/XOEditor.activity/js/activity.js
@@ -30,10 +30,10 @@ function runactivity(act,xocolor,doc,colors,env,datastore,tutorial){
 
 	function init(){
 		canvas = document.getElementById('actualcanvas');
-    	if(window.innerWidth <= 667) {
+    	if(window.innerWidth <= 750) {
 				canvas.width = window.innerWidth;
 			} else {
-				canvas.width = 667;
+				canvas.width = 750;
 			}
     	canvas.height = window.innerHeight-55;
 
@@ -49,10 +49,10 @@ function runactivity(act,xocolor,doc,colors,env,datastore,tutorial){
 
 	    window.addEventListener('resize', resizeCanvas, false);
 	    function resizeCanvas() {
-				if(window.innerWidth <= 667) {
+				if(window.innerWidth <= 750) {
 					canvas.width = window.innerWidth;
 				} else {
-					canvas.width = 667;
+					canvas.width = 750;
 				}
 				canvas.height = window.innerHeight-55;
 				stage.update();

--- a/activities/XOEditor.activity/js/activity.js
+++ b/activities/XOEditor.activity/js/activity.js
@@ -30,7 +30,11 @@ function runactivity(act,xocolor,doc,colors,env,datastore,tutorial){
 
 	function init(){
 		canvas = document.getElementById('actualcanvas');
-    	canvas.width = window.innerWidth;
+    	if(window.innerWidth <= 667) {
+				canvas.width = window.innerWidth;
+			} else {
+				canvas.width = 667;
+			}
     	canvas.height = window.innerHeight-55;
 
     	stage = new createjs.Stage(canvas);
@@ -45,10 +49,14 @@ function runactivity(act,xocolor,doc,colors,env,datastore,tutorial){
 
 	    window.addEventListener('resize', resizeCanvas, false);
 	    function resizeCanvas() {
-	        canvas.width = window.innerWidth;
-	        canvas.height = window.innerHeight-55;
-	        stage.update();
-	        location.reload();
+				if(window.innerWidth <= 667) {
+					canvas.width = window.innerWidth;
+				} else {
+					canvas.width = 667;
+				}
+				canvas.height = window.innerHeight-55;
+				stage.update();
+				location.reload();
 	    }
 
 	    e = new Editor(stage,xocolor,doc,colors,act,env,datastore);


### PR DESCRIPTION
Fixes #665. I have added a break-point for width at 750px in the resize event listener, up to which the resizing seems responsive.

![image](https://user-images.githubusercontent.com/40134655/76138027-80629b80-6069-11ea-8d78-68ffe88f612c.png)
