### PR TITLE
[Issue #671 fix]Fixed transparent background of dialog box

### DIFF
--- a/activities/Markdown.activity/css/activity.css
+++ b/activities/Markdown.activity/css/activity.css
@@ -107,6 +107,12 @@ blockquote {
 	border-left: 3px groove black;
 }
 
+.wmd-prompt-dialog {
+	background: #282828;
+	color: white;
+	padding: 10px;
+}
+
 
 @media screen and (max-width: 480px) {
 	#wmd-showHidePreview-button


### PR DESCRIPTION
Fixes #671. Added a background matching the toolbar color for consistency.

![markdownBGFix](https://user-images.githubusercontent.com/40134655/76141102-1ce76680-6087-11ea-9008-190c3b455539.jpg)
