### PR TITLE
[Issue #673 fix] Fixed opening links in Markdown

### DIFF
--- a/activities/Markdown.activity/lib/Markdown.Converter.js
+++ b/activities/Markdown.activity/lib/Markdown.Converter.js
@@ -621,7 +621,7 @@ else
             }
             url = encodeProblemUrlChars(url);
             url = escapeCharacters(url, "*_");
-            var result = "<a href=\"" + url + "\"";
+            var result = "<a target=\"_blank\" href=\"" + url + "\"";
 
             if (title != "") {
                 title = attributeEncode(title);


### PR DESCRIPTION
Fixes #673. The links will now open in a new tab.

![markdownLinkFix](https://user-images.githubusercontent.com/40134655/76141461-86b53f80-608a-11ea-980f-98578b60126c.gif)
