### PR TITLE
[Issue #733 fix] Made Labyrinth font buttons visible on small screens

### DIFF
--- a/activities/LabyrinthJS.activity/css/activity.css
+++ b/activities/LabyrinthJS.activity/css/activity.css
@@ -354,25 +354,13 @@ body {
    visibility: hidden;
    width: 0px;
  }
-
- #sub-toolbar #fontminus-button {
-   visibility: hidden;
- }
-
- #sub-toolbar #font-button {
-   visibility: hidden;
- }
-
  #fontpalette {
-   left: 0px !important;
- }
-
- #sub-toolbar #fontplus-button {
-   visibility: hidden;
- }
+    left: initial !important;
+    right: 0px !important;
+  }
 }
 
-@media screen and (max-width: 810px) {
+@media screen and (max-width: 820px) {
  .search-field-input {
   width: 120px;
  }
@@ -393,6 +381,22 @@ body {
     #help-button {
         visibility: hidden;
         width: 0px;
+    }
+    
+    #sub-toolbar #fontminus-button {
+      display: none;
+    }
+
+    #sub-toolbar #font-button {
+      display: none;
+    }
+
+    #fontpalette {
+      left: 0px !important;
+    }
+
+    #sub-toolbar #fontplus-button {
+      display: none;
     }
 }
 


### PR DESCRIPTION
Fixes #733. I have made the break-point for the font buttons equal to the help button. Also fixed overflow of font palette on some screens.

![image](https://user-images.githubusercontent.com/40134655/77413163-f0508000-6de4-11ea-91c7-50a81e5a4729.png)
