### PR TITLE
[Issue #739 fix] Keyboard overlap fix on Android

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -16,6 +16,7 @@
 	</author>
 
 	<preference name="Fullscreen" value="true" />
+	<preference name="resizeOnFullScreen" value="true" />
 
 	<preference name="Orientation" value="landscape" />
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -1138,7 +1138,6 @@ body {
 
 .first-namebox {
 	height: 100%;
-	padding-bottom: 100%;
 }
 
 .first-nameline {
@@ -1159,7 +1158,6 @@ body {
 
 .first-serverbox {
 	height: 100%;
-	padding-bottom: 100%;
 }
 
 .first-serverline {
@@ -1253,7 +1251,6 @@ body {
 
 .first-passbox {
 	height: 100%;
-	padding-bottom: 100%;
 }
 
 .first-input {


### PR DESCRIPTION
Fixes #739.
The issue targets the apps that run in fullscreen (like Sugarizer) where resizing of the UI is disallowed. I researched about this issue and found a Cordova plugin which detects the opening/closing of virtual keyboard on fullscreen and provides a workaround for the resizing issue.

*Plugin*: https://github.com/ionic-team/cordova-plugin-ionic-keyboard

This plugin should be added to the APK builder (make_android.sh file):
```
cordova plugin add cordova-plugin-ionic-keyboard@2.2.0
```
I have provided the config needed for resizing and also removed the padding on login screens in this PR.

**Results**

Login:
![20-03-25-16-25-05](https://user-images.githubusercontent.com/40134655/77535722-1ba89d00-6ec1-11ea-8936-65e75b2670f3.gif)

Markdown:
![20-03-25-16-28-03](https://user-images.githubusercontent.com/40134655/77535731-1d726080-6ec1-11ea-8ab9-471c09895c9d.gif)

Get Things Done:
![20-03-25-16-29-06](https://user-images.githubusercontent.com/40134655/77535733-1ea38d80-6ec1-11ea-9a3f-65bc086c8a9a.gif)

Writer:
![20-03-25-16-35-22](https://user-images.githubusercontent.com/40134655/77535736-1f3c2400-6ec1-11ea-8d84-49287390d249.gif)

Added the required plugin to the sugarizer-apkbuilder repository in llaske/sugarizer-apkbuilder#2. Please review @llaske.