### PR TITLE
[Issue #743 fix] Fixed canvas overflow in Grid Paint

### DIFF
--- a/activities/Gridpaint.activity/js/events.js
+++ b/activities/Gridpaint.activity/js/events.js
@@ -44,7 +44,7 @@ function eventInit(){
 }
 
 function computeSize() {
-	var wsize = document.body.clientHeight-(document.getElementById("unfullscreen-button").style.visibility=="hidden"?55:0);
+	var wsize = document.body.clientHeight-(document.getElementById("unfullscreen-button").style.visibility!="visible"?55:0);
 	zoom = wsize/748;
 	var leftMargin = (document.body.clientWidth-1024*zoom)/2;
 	document.getElementById("frame").style.marginLeft = leftMargin+"px";


### PR DESCRIPTION
Fixes #743. The visibility property of unfullscreen-button returns an empty string until it appears which caused the overflow.

![gridPaintOverflowFix](https://user-images.githubusercontent.com/40134655/77765355-28b1c180-7064-11ea-8fdf-e452f018e793.jpg)
