### PR TITLE
[Issue #789 fix] Splitbar fix in Chrome

### DIFF
--- a/activities/Clock.activity/css/activity.css
+++ b/activities/Clock.activity/css/activity.css
@@ -31,6 +31,11 @@ canvas {
   margin: 0;
 }
 
+.toolbar hr {
+  vertical-align: bottom;
+  margin-bottom: 10px;
+}
+
 #main-toolbar #activity-button {
   background-image: url(../activity/activity-clock.svg);
 }


### PR DESCRIPTION
Fixes #789.

The splitbars implemented in the Clock activity use the `<hr>` tags except for the normally used `<div class="splitbar">`. Due to the hr tags being given `display: inline-block`, they create a problem in Firefox where the base of the line starts from the center of the container. Currently, a negative bottom margin was given to fix the problem in Firefox which gave rise to the half-bars in Chrome.

I fixed this issue by setting the `vertical-align` property and fixing margins on the hr tags. Replacing the hr tags with div's can also be implemented but I think this works fine.

Chrome:
![image](https://user-images.githubusercontent.com/40134655/80292069-cdf9ab80-8770-11ea-81b9-00388ff47ddd.png)
