### PR TITLE
Removed resize option from textarea in Shared Notes

### DIFF
--- a/activities/SharedNotes.activity/js/activity.js
+++ b/activities/SharedNotes.activity/js/activity.js
@@ -207,6 +207,7 @@ define(["sugar-web/activity/activity","sugar-web/datastore","notepalette","zoomp
 			textValue.style.top = (55 + position.y + delta) + "px";
 			textValue.style.width = 190 * zoom + "px";
 			textValue.style.height = 190 * zoom + "px";
+			textValue.style.resize = 'none';
 			if (textValue.value == defaultText)
 				textValue.setSelectionRange(0, textValue.value.length);
 			else


### PR DESCRIPTION
The textarea shows a resize option in the bottom corner but the notes can not be resized.

![sharedNotesResize](https://user-images.githubusercontent.com/40134655/83335924-b2cd0f00-a2cd-11ea-814a-f3bc7e1221d7.gif)

Removed this option.
