### PR TITLE
adding media queries to hide palettes on smaller and medium screen

### DIFF
--- a/activities/Constellation.activity/css/activity.css
+++ b/activities/Constellation.activity/css/activity.css
@@ -39,6 +39,26 @@
 	overflow-x: hidden;
 }
 
+@media screen and (max-width: 711px) {
+  #main-toolbar #view-button{
+  	display: none;
+  }
+
+  #view-palette {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 660px) {
+  #main-toolbar #world-button{
+  	display: none;
+  }
+
+  #world-palette {
+    display: none;
+  }
+}
+
 .tutorial-title {
 	background-color: #808080 !important;
 	color: #ffffff !important;

--- a/activities/Constellation.activity/lib/viewpalette.js
+++ b/activities/Constellation.activity/lib/viewpalette.js
@@ -14,7 +14,7 @@ define(["viewpalettetemplate",
         var descriptionLabel;
         var descriptionBox;
 
-        this.getPalette().id = "activity-palette";
+        this.getPalette().id = "view-palette";
 
         var containerElem = document.createElement('div');
         containerElem.innerHTML = template;

--- a/activities/Constellation.activity/lib/viewpalettetemplate.js
+++ b/activities/Constellation.activity/lib/viewpalettetemplate.js
@@ -42,6 +42,8 @@ define(function () {
         invoker.addEventListener('click', function (event) {
             if (!that.invoker.classList.contains("toolbutton")) {
                 updatePosition(event.x, event.y);
+            } else {
+              updatePosition();
             }
             that.toggle();
         });

--- a/activities/Constellation.activity/lib/worldpalette.js
+++ b/activities/Constellation.activity/lib/worldpalette.js
@@ -14,7 +14,7 @@ define(["worldpalettetemplate",
         var descriptionLabel;
         var descriptionBox;
 
-        this.getPalette().id = "activity-palette";
+        this.getPalette().id = "world-palette";
 
         var containerElem = document.createElement('div');
         containerElem.innerHTML = template;

--- a/activities/Constellation.activity/lib/worldpalettetemplate.js
+++ b/activities/Constellation.activity/lib/worldpalettetemplate.js
@@ -42,6 +42,8 @@ define(function () {
         invoker.addEventListener('click', function (event) {
             if (!that.invoker.classList.contains("toolbutton")) {
                 updatePosition(event.x, event.y);
+            } else {
+              updatePosition();
             }
             that.toggle();
         });


### PR DESCRIPTION
This PR
- adding media queries to hide palettes on smaller and medium screen
- the palettes are also updated for the bug #807 like [here](https://github.com/llaske/sugarizer/commit/f7686be32f246a2973d0a35bf84fd17fadecb2fa)