### PR TITLE
Updated SugarDevice to add platform methods

### DIFF
--- a/activities/ActivityTemplate/VueJS/js/components/SugarDevice.js
+++ b/activities/ActivityTemplate/VueJS/js/components/SugarDevice.js
@@ -16,8 +16,7 @@ Vue.component('sugar-device', {
 	mounted: function () {
 		var vm = this;
 		//Accelerometer
-		var useragent = navigator.userAgent.toLowerCase();
-		if (useragent.indexOf('android') != -1 || useragent.indexOf('iphone') != -1 || useragent.indexOf('ipad') != -1 || useragent.indexOf('ipod') != -1 || useragent.indexOf('mozilla/5.0 (mobile') != -1) {
+		if (this.isMobile()) {
 			document.addEventListener('deviceready', function () {
 				vm.readyToWatch = true;
 			}, false);
@@ -33,6 +32,67 @@ Vue.component('sugar-device', {
 		}
 	},
 	methods: {
+		isMobile() {
+			var userAgent = navigator.userAgent;
+			if (/Mobile|mini|Fennec|Android|iP(ad|od|hone)/.test(userAgent)) {
+				return true;
+			}
+			return false;
+		},
+		isElectron() {
+			var userAgent = navigator.userAgent;
+			if (/Electron/.test(userAgent)) {
+				return true;
+			}
+			return false;
+		},
+		isApp() {
+			return document.location.protocol.substr(0,4) != "http";
+		},	
+		isWebApp() {
+			if (!this.isMobile() && !this.isElectron() && !this.isApp()) {
+				return true;
+			}
+			return false;
+		},
+		getOS() {
+			var userAgent = navigator.userAgent;
+			var clientStrings = [
+				{ s: 'Windows 10', r: /(Windows 10.0|Windows NT 10.0)/ },
+				{ s: 'Windows 8.1', r: /(Windows 8.1|Windows NT 6.3)/ },
+				{ s: 'Windows 8', r: /(Windows 8|Windows NT 6.2)/ },
+				{ s: 'Windows 7', r: /(Windows 7|Windows NT 6.1)/ },
+				{ s: 'Windows Vista', r: /Windows NT 6.0/ },
+				{ s: 'Windows Server 2003', r: /Windows NT 5.2/ },
+				{ s: 'Windows XP', r: /(Windows NT 5.1|Windows XP)/ },
+				{ s: 'Windows 2000', r: /(Windows NT 5.0|Windows 2000)/ },
+				{ s: 'Windows ME', r: /(Win 9x 4.90|Windows ME)/ },
+				{ s: 'Windows 98', r: /(Windows 98|Win98)/ },
+				{ s: 'Windows 95', r: /(Windows 95|Win95|Windows_95)/ },
+				{ s: 'Windows NT 4.0', r: /(Windows NT 4.0|WinNT4.0|WinNT|Windows NT)/ },
+				{ s: 'Windows CE', r: /Windows CE/ },
+				{ s: 'Windows 3.11', r: /Win16/ },
+				{ s: 'Android', r: /Android/ },
+				{ s: 'Open BSD', r: /OpenBSD/ },
+				{ s: 'Sun OS', r: /SunOS/ },
+				{ s: 'Chrome OS', r: /CrOS/ },
+				{ s: 'Linux', r: /(Linux|X11(?!.*CrOS))/ },
+				{ s: 'iOS', r: /(iPhone|iPad|iPod)/ },
+				{ s: 'Mac OS X', r: /Mac OS X/ },
+				{ s: 'Mac OS', r: /(MacPPC|MacIntel|Mac_PowerPC|Macintosh)/ },
+				{ s: 'QNX', r: /QNX/ },
+				{ s: 'UNIX', r: /UNIX/ },
+				{ s: 'BeOS', r: /BeOS/ },
+				{ s: 'OS/2', r: /OS\/2/ },
+				{ s: 'Search Bot', r: /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/ }
+			];
+			for (var cs of clientStrings) {
+				if (cs.r.test(userAgent)) {
+					return cs.s;
+				}
+			}
+		},
+
 		watchAcceleration: function (frequency) {
 			var vm = this;
 			var accelerometer = new Accelerometer({ frequency: frequency });

--- a/activities/Curriculum.activity/js/components/SugarDevice.js
+++ b/activities/Curriculum.activity/js/components/SugarDevice.js
@@ -16,8 +16,7 @@ Vue.component('sugar-device', {
 	mounted: function () {
 		var vm = this;
 		//Accelerometer
-		var useragent = navigator.userAgent.toLowerCase();
-		if (useragent.indexOf('android') != -1 || useragent.indexOf('iphone') != -1 || useragent.indexOf('ipad') != -1 || useragent.indexOf('ipod') != -1 || useragent.indexOf('mozilla/5.0 (mobile') != -1) {
+		if (this.isMobile()) {
 			document.addEventListener('deviceready', function () {
 				vm.readyToWatch = true;
 			}, false);
@@ -33,6 +32,67 @@ Vue.component('sugar-device', {
 		}
 	},
 	methods: {
+		isMobile() {
+			var userAgent = navigator.userAgent;
+			if (/Mobile|mini|Fennec|Android|iP(ad|od|hone)/.test(userAgent)) {
+				return true;
+			}
+			return false;
+		},
+		isElectron() {
+			var userAgent = navigator.userAgent;
+			if (/Electron/.test(userAgent)) {
+				return true;
+			}
+			return false;
+		},
+		isApp() {
+			return document.location.protocol.substr(0,4) != "http";
+		},	
+		isWebApp() {
+			if (!this.isMobile() && !this.isElectron() && !this.isApp()) {
+				return true;
+			}
+			return false;
+		},
+		getOS() {
+			var userAgent = navigator.userAgent;
+			var clientStrings = [
+				{ s: 'Windows 10', r: /(Windows 10.0|Windows NT 10.0)/ },
+				{ s: 'Windows 8.1', r: /(Windows 8.1|Windows NT 6.3)/ },
+				{ s: 'Windows 8', r: /(Windows 8|Windows NT 6.2)/ },
+				{ s: 'Windows 7', r: /(Windows 7|Windows NT 6.1)/ },
+				{ s: 'Windows Vista', r: /Windows NT 6.0/ },
+				{ s: 'Windows Server 2003', r: /Windows NT 5.2/ },
+				{ s: 'Windows XP', r: /(Windows NT 5.1|Windows XP)/ },
+				{ s: 'Windows 2000', r: /(Windows NT 5.0|Windows 2000)/ },
+				{ s: 'Windows ME', r: /(Win 9x 4.90|Windows ME)/ },
+				{ s: 'Windows 98', r: /(Windows 98|Win98)/ },
+				{ s: 'Windows 95', r: /(Windows 95|Win95|Windows_95)/ },
+				{ s: 'Windows NT 4.0', r: /(Windows NT 4.0|WinNT4.0|WinNT|Windows NT)/ },
+				{ s: 'Windows CE', r: /Windows CE/ },
+				{ s: 'Windows 3.11', r: /Win16/ },
+				{ s: 'Android', r: /Android/ },
+				{ s: 'Open BSD', r: /OpenBSD/ },
+				{ s: 'Sun OS', r: /SunOS/ },
+				{ s: 'Chrome OS', r: /CrOS/ },
+				{ s: 'Linux', r: /(Linux|X11(?!.*CrOS))/ },
+				{ s: 'iOS', r: /(iPhone|iPad|iPod)/ },
+				{ s: 'Mac OS X', r: /Mac OS X/ },
+				{ s: 'Mac OS', r: /(MacPPC|MacIntel|Mac_PowerPC|Macintosh)/ },
+				{ s: 'QNX', r: /QNX/ },
+				{ s: 'UNIX', r: /UNIX/ },
+				{ s: 'BeOS', r: /BeOS/ },
+				{ s: 'OS/2', r: /OS\/2/ },
+				{ s: 'Search Bot', r: /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/ }
+			];
+			for (var cs of clientStrings) {
+				if (cs.r.test(userAgent)) {
+					return cs.s;
+				}
+			}
+		},
+
 		watchAcceleration: function (frequency) {
 			var vm = this;
 			var accelerometer = new Accelerometer({ frequency: frequency });

--- a/activities/MindMath.activity/js/components/SugarDevice.js
+++ b/activities/MindMath.activity/js/components/SugarDevice.js
@@ -16,8 +16,7 @@ Vue.component('sugar-device', {
 	mounted: function () {
 		var vm = this;
 		//Accelerometer
-		var useragent = navigator.userAgent.toLowerCase();
-		if (useragent.indexOf('android') != -1 || useragent.indexOf('iphone') != -1 || useragent.indexOf('ipad') != -1 || useragent.indexOf('ipod') != -1 || useragent.indexOf('mozilla/5.0 (mobile') != -1) {
+		if (this.isMobile()) {
 			document.addEventListener('deviceready', function () {
 				vm.readyToWatch = true;
 			}, false);
@@ -33,6 +32,67 @@ Vue.component('sugar-device', {
 		}
 	},
 	methods: {
+		isMobile() {
+			var userAgent = navigator.userAgent;
+			if (/Mobile|mini|Fennec|Android|iP(ad|od|hone)/.test(userAgent)) {
+				return true;
+			}
+			return false;
+		},
+		isElectron() {
+			var userAgent = navigator.userAgent;
+			if (/Electron/.test(userAgent)) {
+				return true;
+			}
+			return false;
+		},
+		isApp() {
+			return document.location.protocol.substr(0,4) != "http";
+		},	
+		isWebApp() {
+			if (!this.isMobile() && !this.isElectron() && !this.isApp()) {
+				return true;
+			}
+			return false;
+		},
+		getOS() {
+			var userAgent = navigator.userAgent;
+			var clientStrings = [
+				{ s: 'Windows 10', r: /(Windows 10.0|Windows NT 10.0)/ },
+				{ s: 'Windows 8.1', r: /(Windows 8.1|Windows NT 6.3)/ },
+				{ s: 'Windows 8', r: /(Windows 8|Windows NT 6.2)/ },
+				{ s: 'Windows 7', r: /(Windows 7|Windows NT 6.1)/ },
+				{ s: 'Windows Vista', r: /Windows NT 6.0/ },
+				{ s: 'Windows Server 2003', r: /Windows NT 5.2/ },
+				{ s: 'Windows XP', r: /(Windows NT 5.1|Windows XP)/ },
+				{ s: 'Windows 2000', r: /(Windows NT 5.0|Windows 2000)/ },
+				{ s: 'Windows ME', r: /(Win 9x 4.90|Windows ME)/ },
+				{ s: 'Windows 98', r: /(Windows 98|Win98)/ },
+				{ s: 'Windows 95', r: /(Windows 95|Win95|Windows_95)/ },
+				{ s: 'Windows NT 4.0', r: /(Windows NT 4.0|WinNT4.0|WinNT|Windows NT)/ },
+				{ s: 'Windows CE', r: /Windows CE/ },
+				{ s: 'Windows 3.11', r: /Win16/ },
+				{ s: 'Android', r: /Android/ },
+				{ s: 'Open BSD', r: /OpenBSD/ },
+				{ s: 'Sun OS', r: /SunOS/ },
+				{ s: 'Chrome OS', r: /CrOS/ },
+				{ s: 'Linux', r: /(Linux|X11(?!.*CrOS))/ },
+				{ s: 'iOS', r: /(iPhone|iPad|iPod)/ },
+				{ s: 'Mac OS X', r: /Mac OS X/ },
+				{ s: 'Mac OS', r: /(MacPPC|MacIntel|Mac_PowerPC|Macintosh)/ },
+				{ s: 'QNX', r: /QNX/ },
+				{ s: 'UNIX', r: /UNIX/ },
+				{ s: 'BeOS', r: /BeOS/ },
+				{ s: 'OS/2', r: /OS\/2/ },
+				{ s: 'Search Bot', r: /(nuhk|Googlebot|Yammybot|Openbot|Slurp|MSNBot|Ask Jeeves\/Teoma|ia_archiver)/ }
+			];
+			for (var cs of clientStrings) {
+				if (cs.r.test(userAgent)) {
+					return cs.s;
+				}
+			}
+		},
+
 		watchAcceleration: function (frequency) {
 			var vm = this;
 			var accelerometer = new Accelerometer({ frequency: frequency });

--- a/docs/tutorial/VueJS/step6.md
+++ b/docs/tutorial/VueJS/step6.md
@@ -173,21 +173,7 @@ Now, let's update our Pawn activity to integrate presence. Start first by handli
 ```
 The `presence-event` is the name of the event for which you wish to attach a listener for. This `SugarToolitem` detects this and automatically emits a Vue.js event with the same name, when this event is received from the palette. So, when we click the Share button, the `shared` event is received from the palette to the toolitem, and is then emitted as a Vue event to the instance. This will be handled by the `onShared()` method of the component.
 
->**NOTE**: If you wish to perform some tasks when an activity is shared, you can add a custom intermediate method as a handler to the `shared` event on this toolitem. 
->
->`v-on:shared="yourCustomHandler"`
->
->You will receive 2 arguements: `event` and `paletteObject`. Make sure to call the default method `SugarPresence.onShared` in the end of this custom method to keep the existing workflow.
->
->```js
-> // in activity.js
->yourCustomHandler: function(event, paletteObject) {
->	// Your custom code here
->
->	// Remember to call the default method
->	this.SugarPresence.onShared(event, paletteObject);
->}
->```
+>**NOTE**: The handler for the `shared` event receives two arguements: `event` and `paletteObject`. If you wish to perform some tasks when an activity is shared, you can call your custom intermediate method here and in the end call `SugarPresence.onShared` with the same arguements.
 
 We will also use the `v-if` directive to render this button only `SugarPresence` component exists (This also makes sure `onShared()` is defined at the time of binding).
 
@@ -211,7 +197,7 @@ If the activity is connected (i.e. `SugarPresence.isConnected()` is `true` which
 
 That's all we need to create a shared activity and let it appear on the Neighborhood view of other users. We have now to handle what happens when a user clicks on the Join menu. In that case, your activity is automatically open by Sugarizer with a specific parameter in the environment. Another situation where component makes the life easier, it handles the existence of this parameter (`shareId`) and automatically intializes the presence object.
 
-In case you wish to perform some action only when the activity is a shared instance, you can make use of the `journal-shared-instance` event from `SugarJounral` which is emitted on startup of a shared instance.
+In case you wish to perform some action only when the activity is a shared instance, you can make use of the `journal-shared-instance` event from `SugarJournal` which is emitted on startup of a shared instance.
 
 You can add a handler to this in the `sugar-journal` instance like this in `index.html`:
 ```html

--- a/docs/tutorial/VueJS/step6.md
+++ b/docs/tutorial/VueJS/step6.md
@@ -173,6 +173,22 @@ Now, let's update our Pawn activity to integrate presence. Start first by handli
 ```
 The `presence-event` is the name of the event for which you wish to attach a listener for. This `SugarToolitem` detects this and automatically emits a Vue.js event with the same name, when this event is received from the palette. So, when we click the Share button, the `shared` event is received from the palette to the toolitem, and is then emitted as a Vue event to the instance. This will be handled by the `onShared()` method of the component.
 
+>**NOTE**: If you wish to perform some tasks when an activity is shared, you can add a custom intermediate method as a handler to the `shared` event on this toolitem. 
+>
+>`v-on:shared="yourCustomHandler"`
+>
+>You will receive 2 arguements: `event` and `paletteObject`. Make sure to call the default method `SugarPresence.onShared` in the end of this custom method to keep the existing workflow.
+>
+>```js
+> // in activity.js
+>yourCustomHandler: function(event, paletteObject) {
+>	// Your custom code here
+>
+>	// Remember to call the default method
+>	this.SugarPresence.onShared(event, paletteObject);
+>}
+>```
+
 We will also use the `v-if` directive to render this button only `SugarPresence` component exists (This also makes sure `onShared()` is defined at the time of binding).
 
 Now that our activity is shared, we have to slightly update the Add button listener. Because now we should notify other users when a new pawn is played. Here's how the new listener will look like in `js/activity.js`:


### PR DESCRIPTION
Added methods to detect the current platform in an activity: `isApp`, `isWebApp`, `isElectron`, `isMobile`.