### PR TITLE
Fixed script imports for Electron and other bugs in Curriculum

### DIFF
--- a/activities/Curriculum.activity/index.html
+++ b/activities/Curriculum.activity/index.html
@@ -21,13 +21,14 @@
 	<link rel="stylesheet" href="css/Rewards.css">
 	<link rel="stylesheet" href="css/Export.css">
 	<link rel="stylesheet" href="css/bootstrap-tour-standalone.min.css">
+	<script>if (typeof module === 'object') {window.module = module; module = undefined;}</script>
 	<script src="lib/vue.min.js"></script>
 	<script src="lib/jquery.min.js"></script>
 	<script src="lib/bootstrap-tour-standalone.min.js"></script>
-	<script>if (window.module) module = window.module;</script>
 	<script src="lib/Sortable.min.js"></script>
 	<script src="lib/vuedraggable.umd.min.js"></script>
 	<script src="lib/jspdf.min.js"></script>
+	<script>if (window.module) module = window.module;</script>
 	<script src="lib/require.js"></script>
 </head>
 

--- a/activities/Curriculum.activity/js/activity.js
+++ b/activities/Curriculum.activity/js/activity.js
@@ -495,6 +495,8 @@ var app = new Vue({
 		},
 
 		switchSkillLevel: function () {
+			if(this.sharedInstance) return;
+			
 			var skillObj = this.user.skills[this.selectedCategoryId][this.selectedSkillId];
 			var value = skillObj.acquired;
 			value = (value + 1) % (this.notationLevel + 1);
@@ -747,6 +749,7 @@ var app = new Vue({
 			if(data.currentView == 'template-selection') {
 				this.currentView = data.currentView;
 			} else {
+				this.sharedInstance = data.sharedInstance;
 				this.templateTitle = data.templateTitle;
 				this.templateImage = data.templateImage;
 				this.notationLevel = data.notationLevel;
@@ -769,11 +772,13 @@ var app = new Vue({
 			switch(msg.content.action) {
 				case 'init':
 					this.sharedInstance = true;
+					this.templateTitle = msg.content.data.templateTitle;
 					this.categories = msg.content.data.categories;
 					this.user = msg.content.data.user;
 					this.notationLevel = msg.content.data.notationLevel;
 					this.currentenv = {};
 					this.currentenv.user = msg.user;
+					this.rewardsInit = true;
 					break;
 				case 'updateCategories':
 					this.categories = msg.content.data.categories;
@@ -794,6 +799,7 @@ var app = new Vue({
 					content: {
 						action: 'init',
 						data: {
+							templateTitle: this.templateTitle,
 							categories: this.categories,
 							user: this.user,
 							notationLevel: this.notationLevel
@@ -1016,6 +1022,7 @@ var app = new Vue({
 				}
 			} else {
 				context = {
+					sharedInstance: this.sharedInstance,
 					templateTitle: this.templateTitle,
 					templateImage: this.templateImage,
 					notationLevel: this.notationLevel,


### PR DESCRIPTION
Drag-to-reorder for categories/skills will work now in the Electron environment.

Other bugs fixed:
* Template title wasn't being sent to the connected user so the export files had incorrect names.
* Trophies were not visible to the connected user.
* A shared instance, when closed and opened from the Journal opened like the host instance.
* Medal was clickable on the connected user's side allowing change in acquired state.