### PR TITLE
[Issue #850 fix] Fixed empty context issue on accidental exit of new activity instance

### DIFF
--- a/activities/Curriculum.activity/js/activity.js
+++ b/activities/Curriculum.activity/js/activity.js
@@ -764,8 +764,8 @@ var app = new Vue({
 
 		onJournalNewInstace: function () {
 			this.currentView = 'template-selection';
-			// this.importSkills();
-			// this.addAchievementsToUser();
+			// Fix in case of accidental exit
+			this.saveContextToJournal();
 		},
 
 		onNetworkDataReceived: function (msg) {
@@ -1014,7 +1014,7 @@ var app = new Vue({
 			this.$refs.SugarTutorial.show(steps);
 		},
 
-		onStop: function () {
+		saveContextToJournal: function() {
 			var context;
 			if(this.currentView == 'template-selection') {
 				context = {
@@ -1034,6 +1034,10 @@ var app = new Vue({
 				};
 			}
 			this.$refs.SugarJournal.saveData(context);
+		},
+
+		onStop: function () {
+			this.saveContextToJournal();
 		}
 	}
 });

--- a/activities/EbookReader.activity/js/activity.js
+++ b/activities/EbookReader.activity/js/activity.js
@@ -53,6 +53,8 @@ var app = new Vue({
 					});
 				} else {
 					vm.loadLibrary(defaultUrlLibrary);
+					// Fix in case of accidental exit
+					vm.saveContextToJournal();
 				}
 			});
 		});
@@ -243,7 +245,7 @@ var app = new Vue({
 			this.$refs.tutorial.show(options);
 		},
 
-		onStop: function() {
+		saveContextToJournal: function() {
 			// Save current library in Journal on Stop
 			var vm = this;
 			vm.saveContext();
@@ -265,6 +267,10 @@ var app = new Vue({
 					}
 				});
 			});
+		},
+
+		onStop: function() {
+			this.saveContextToJournal();
 		}
 	}
 });

--- a/activities/Vote.activity/js/activity.js
+++ b/activities/Vote.activity/js/activity.js
@@ -436,6 +436,8 @@ var app = new Vue({
 
 		onJournalNewInstance: function (error) {
 			this.currentView = "polls-grid";
+			// Fix in case of accidental exit
+			this.saveContextToJournal();
 		},
 
 		onJournalSharedInstance: function () {
@@ -809,13 +811,17 @@ var app = new Vue({
 			this.$refs.SugarTutorial.show(steps);
 		},
 
-		onStop() {
+		saveContextToJournal() {
 			var context = {
 				polls: this.polls,
 				realTimeResults: this.realTimeResults,
 				history: this.history
 			};
 			this.$refs.SugarJournal.saveData(context);
+		},
+
+		onStop() {
+			this.saveContextToJournal();
 		}
 	}
 });


### PR DESCRIPTION
Fixes #850.

Fixed the issue by saving the context of the activity right after it is loaded. Added the fix to Curriculum, Vote and Ebook Reader. Exerciser needs to be updated in it's source repository.