### PR TITLE
[Issue #854] Fixed uniquie ID issue on Vote and Curriculum

### DIFF
--- a/activities/Curriculum.activity/js/Settings.js
+++ b/activities/Curriculum.activity/js/Settings.js
@@ -101,13 +101,13 @@ var CategorySettings = {
 		},
 
 		addCategory: function() {
-			var nextId = this.categories.length;
-			this.category.id = nextId;
+			var maxId = this.categories.reduce((max, category) => max = Math.max(category.id, max), -1);
+			this.category.id = maxId + 1;
 			this.categories.push(this.category);
 			setTimeout(function () {
 				content.scrollTop = content.scrollHeight;
 			}, 250);
-			this.$set(this.user.skills, nextId, new Object());
+			this.$set(this.user.skills, maxId + 1, new Object());
 		}
 	}
 }
@@ -239,13 +239,13 @@ var SkillSettings = {
 		},
 
 		addSkill: function(catIndex) {
-			var nextId = this.categories[catIndex].skills.length;
-			this.skill.id = nextId;
+			var maxId = this.categories[catIndex].skills.reduce((max, skill) => max = Math.max(skill.id, max), -1);
+			this.skill.id = maxId + 1;
 			this.categories[catIndex].skills.push(this.skill);
 			setTimeout(function () {
 				content.scrollTop = content.scrollHeight;
 			}, 250);
-			this.$set(this.user.skills[this.categoryId], nextId, {
+			this.$set(this.user.skills[this.categoryId], maxId + 1, {
 				acquired: 0,
 				media: {}
 			});

--- a/activities/Vote.activity/js/Settings.js
+++ b/activities/Vote.activity/js/Settings.js
@@ -163,8 +163,8 @@ var PollSettings = {
 		},
 
 		addPoll() {
-			var nextId = this.polls.length;
-			this.poll.id = nextId;
+			var maxId = this.polls.reduce((max, poll) => max = Math.max(poll.id, max), -1);
+			this.poll.id = maxId + 1;
 			this.polls.push(this.poll);
 			this.$emit('poll-added', this.poll.id);
 		}


### PR DESCRIPTION
Fixes #854.

The issue was caused due to the new poll/category/skill taking it's `id` as the *length* of the corresponding array of that entity. This caused 2 entities to have the same ID.

Fixed the issue by finding the max `id` from the array and setting `maxId + 1` as the new ID for the entity. This makes sure the new `id` is unique. Fixed the issue in both Vote and Curriculum.