### PR TITLE
Update noServerMode behavior

### DIFF
--- a/js/constant.js
+++ b/js/constant.js
@@ -48,6 +48,7 @@ constant.webAppType = 0; // thinClientType
 constant.appType = 1;  // clientType
 constant.noServerMode = false;
 constant.noSignupMode = false;
+constant.noLoginMode = false;
 
 constant.staticInitActivitiesURL = "activities.json";
 constant.http = "http://";

--- a/js/firstscreen.js
+++ b/js/firstscreen.js
@@ -183,8 +183,8 @@ enyo.kind({
 		}
 
 		this.$.stopbutton.setShowing(vstop);
-		this.$.login.setShowing(vlogin);
-		this.$.logintext.setShowing(vlogintext);
+		this.$.login.setShowing(vlogin && !constant.noLoginMode);
+		this.$.logintext.setShowing(vlogintext && !constant.noLoginMode);
 		this.$.newuser.setShowing(vnewuser && !constant.noSignupMode);
 		this.$.newusertext.setShowing(vnewusertext && !constant.noSignupMode);
 		this.$.namebox.setShowing(vnamebox);
@@ -367,18 +367,19 @@ enyo.kind({
 		this.$.logintext.applyStyle("margin-top", (newUserPosition+constant.sizeNewUser+20)+"px");
 		this.$.logintext.applyStyle("width", constant.sizeNewUser+"px");
 		if (this.history.length) {
-			var left = (canvas_center.x-(constant.sizeNewUser*1.5)-30);
+			var left = (canvas_center.x-(constant.sizeNewUser*1.5)-30+(constant.noLoginMode?120:0));
 			this.$.newuser.applyStyle("margin-left", left+"px");
 			this.$.newusertext.applyStyle("margin-left", left+"px");
 			left += constant.sizeNewUser+30;
 			this.$.login.applyStyle("margin-left", left+"px");
 			this.$.logintext.applyStyle("margin-left", left+"px");
 			left += constant.sizeNewUser+30;
-			this.$.historybox.applyStyle("margin-left", left+"px");
+			this.$.historybox.applyStyle("margin-left", (left+(constant.noLoginMode?-140:0))+"px");
 		} else {
 			var newuser = (constant.noSignupMode?-80:0);
-			this.$.newuser.applyStyle("margin-left", (canvas_center.x-constant.sizeNewUser-25)+"px");
-			this.$.newusertext.applyStyle("margin-left", (canvas_center.x-constant.sizeNewUser-25)+"px");
+			var login = (constant.noLoginMode?80:0);
+			this.$.newuser.applyStyle("margin-left", (canvas_center.x-constant.sizeNewUser-25+login)+"px");
+			this.$.newusertext.applyStyle("margin-left", (canvas_center.x-constant.sizeNewUser-25+login)+"px");
 			this.$.login.applyStyle("margin-left", (canvas_center.x+25+newuser)+"px");
 			this.$.logintext.applyStyle("margin-left", (canvas_center.x+25+newuser)+"px");
 		}

--- a/js/homeview.js
+++ b/js/homeview.js
@@ -670,7 +670,7 @@ enyo.kind({
 			action: enyo.bind(this, "doLogoff"),
 			data: null
 		});
-		if (enyo.platform.electron) {
+		if (enyo.platform.electron || constant.noServerMode) {
 			items.push({
 				icon: {directory: "lib/sugar-web/graphics/icons/actions", icon: "activity-stop.svg"},
 				colorized: false,


### PR DESCRIPTION
Update `noServerMode` option: add a Quit button in the buddy menu.

Add a `noLoginMode` to hide the Login button on the home page.

Specifically the behavior in `noServerMode` with `noLoginMode` when Sugarizer is installed on a micro server in HTTP has been sum up below by Terry:

- A user who starts Sugarizer from the micro server on a browser that has not run Sugarizer previously will be presented with a page showing the New User icon.
- The user clicks on the icon, enters a name, clicks Next, selects a buddy icon color, clicks  Done and continues on to the Sugar favorites menu page.
- Activities that the user opens during the session are recorded in the Journal.
- When the user has finished the session, they click on the Buddy icon select either Quit or Logout.

- If Quit is selected, the XO exit page appears.
    - If the user clicks on the exit page, they will be taken back to the session.
    - The user can close the browser tab. Session data will be saved locally in the browser.
    - If the user subsequently starts Sugarizer again on the same browser (assuming that cached browser data has not been deleted),
       the session will be resumed where it left off ie at the favorites menu page, with previously opened activities shown in the Journal.
    - If the user simply closes the browser tab, the result is essentially the same as using Quit to exit ie the session data is retained.

- If Logout is selected, the user gets a confirmation dialog warning that the session data will be lost.
    - The user is then taken to the New User page, which will also show an icon with the name and buddy icon for the previous session.
    - If multiple New Users have been created, the page will show the last three user names and buddy icons.
    - Clicking on one of the buddy icons will take the user to a new session for the named user (ie no data in the Journal).
    - Starting Sugarizer subsequently on the same browser will show the New User icon and up to three previous user names and buddy icons
       (assuming cached browser data has not been deleted)

- In summary:
    - The browser will retain the data locally for one user/session after a Quit.
    - The browser will retain the name and buddy icon for up to three user/sessions after a Logout.
    - Saved data will persist across a browser / PC restart (provided that cached browser data is not automatically deleted).

 - A user can save and restore data for each activity in a session to/from the PC storage as required from the Journal menu. This allows a user to store their data in a portable form on a USB memory for example.

