### PR TITLE
Fixing the VideoViewer activity's event bubbling issue

### DIFF
--- a/activities/VideoViewer.activity/dialog.js
+++ b/activities/VideoViewer.activity/dialog.js
@@ -135,17 +135,19 @@ enyo.kind({
 	},
 
 	// Process events
-	closeDialog: function() {
+	closeDialog: function (inSender, inEvent) {
 		this.$.video.pause();
 		Util.setReadTime(this.item.code, this.$.video.getCurrentTime());
 		this.$.video.unload();
 		this.item = null;
 		Util.saveContext();
 		this.hide();
+		inEvent.preventDefault();
 		if (Util.onSugar()) {
 			// HACK: Force refresh screen on Sugar to avoid video issue
 			Util.sugar.sendMessage("refresh-screen", Util.context);
 		}
+
 	},
 
 	setFavorite: function() {


### PR DESCRIPTION
On touch screen, when you play a video then touch the close button to go back to the main screen, the fullscreen mode is no longer activated.
Tested on touch screen.

issue #859 solved :)