### PR TITLE
Improved Responsiveness in Game of life Activity

### DIFF
--- a/activities/GameOfLife.activity/css/activity.css
+++ b/activities/GameOfLife.activity/css/activity.css
@@ -230,3 +230,16 @@ canvas {
   background-color: #808080;
   border: 2px solid #808080;
 }
+
+@media screen and (min-width: 641px) and (max-width: 820px) {
+  .generation-container {
+    height: 20px;
+    margin: 10px 0;
+  }
+  .generation-count {
+    font-size: 32px;
+  }
+  canvas {
+    transform: scale(0.8);
+  }
+}

--- a/activities/GameOfLife.activity/css/activity.css
+++ b/activities/GameOfLife.activity/css/activity.css
@@ -233,13 +233,19 @@ canvas {
 
 @media screen and (min-width: 641px) and (max-width: 820px) {
   .generation-container {
-    height: 20px;
-    margin: 10px 0;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 200px;
+    flex-direction: row;
+    height: 10px; 
+    margin: 12px 0; 
+  }
+  .generation-status {
+    margin-top: 10px;
+    font-size: 20px;
   }
   .generation-count {
-    font-size: 32px;
-  }
-  canvas {
-    transform: scale(0.8);
+    font-size: 22px;
   }
 }


### PR DESCRIPTION
Fixes #793 

Used media queries to remove Canvas overflow and make "Generation" visible.

Earlier it is like this: 

![Screenshot from 2020-12-15 19-51-01](https://user-images.githubusercontent.com/60233336/102226872-ed676380-3f0e-11eb-827e-7767e06be84a.png)

Preview after fix:

![Screenshot from 2020-12-15 19-51-55](https://user-images.githubusercontent.com/60233336/102226963-0708ab00-3f0f-11eb-823c-f62e0e4c6957.png)

