### PR TITLE
Remove name and XO icon from Memorize Activity when user left

### DIFF
--- a/activities/Memorize.activity/js/memorize-app.js
+++ b/activities/Memorize.activity/js/memorize-app.js
@@ -786,12 +786,13 @@ define(["activity/sample-ressources", "activity/palettes/template-palette", "act
             }
 
             MemorizeApp.hasLoadedMultiplayer = true;
-
+            MemorizeApp.game.players = [];
 
             if (users.length == 1) {
                 MemorizeApp.isHost = true;
                 MemorizeApp.game.currentPlayer = MemorizeApp.me.networkId;
                 MemorizeApp.game.selectedCards = [];
+                MemorizeApp.game.players.push(users[0]);
                 drawGame();
                 displayUsersAndScores();
                 return;


### PR DESCRIPTION
Fixed #794 

Automatically remove the name and xo icon when more than two users joined. 
Also, will remove the name and xo icon if one out of two users left and add it again when the second user rejoins.

Preview of Fix:

![Memorize](https://user-images.githubusercontent.com/60233336/115432832-775c6b80-a224-11eb-845e-54b494b0ccbf.gif)
