### PR TITLE
Fixed incorrect error message in Calculate activity

### DIFF
--- a/activities/Calculate.activity/js/calculate-activity.js
+++ b/activities/Calculate.activity/js/calculate-activity.js
@@ -164,8 +164,9 @@ function launchCalculation(calcInputValue, labelValue) {
     calculation: calcInputValue,
     graph: false
   };
-
-  if (calcInputValue[0]=='f' && calcInputValue[1]=='('){
+  
+  var reg = /f\(.*\)=[\w]+/;
+  if (reg.test(calcInputValue)){
     calculation.error = "Invalid left hand side of assignment operator =";
     CalculateApp.displayCalculation(calculation);
     return;

--- a/activities/Calculate.activity/js/calculate-activity.js
+++ b/activities/Calculate.activity/js/calculate-activity.js
@@ -165,6 +165,12 @@ function launchCalculation(calcInputValue, labelValue) {
     graph: false
   };
 
+  if (calcInputValue[0]=='f' && calcInputValue[1]=='('){
+    calculation.error = "Invalid left hand side of assignment operator =";
+    CalculateApp.displayCalculation(calculation);
+    return;
+  }
+
   if (labelValue) {
     calculation.label = labelValue;
   }

--- a/activities/Calculate.activity/js/calculate-activity.js
+++ b/activities/Calculate.activity/js/calculate-activity.js
@@ -154,7 +154,12 @@ function launchGraph(calcInputValue, labelValue) {
   CalculateApp.persistCalculations();
   CalculateApp.displayCalculation(calculation);
   if (!calculation.error) {
-    CalculateApp.graph(calculation.calculation);
+    try {
+      CalculateApp.graph(calculation.calculation);
+    } catch (error) {
+      calculation.error= error.message;
+      CalculateApp.displayCalculation(calculation);
+    }
   }
 }
 
@@ -165,13 +170,6 @@ function launchCalculation(calcInputValue, labelValue) {
     graph: false
   };
   
-  var reg = /f\(.*\)=[\w]+/;
-  if (reg.test(calcInputValue)){
-    calculation.error = "Invalid left hand side of assignment operator =";
-    CalculateApp.displayCalculation(calculation);
-    return;
-  }
-
   if (labelValue) {
     calculation.label = labelValue;
   }

--- a/activities/Calculate.activity/js/calculate-app.js
+++ b/activities/Calculate.activity/js/calculate-app.js
@@ -177,7 +177,13 @@ var CalculateApp = {
       node.innerHTML = CalculateApp.libs.mustache.render(getErrorTemplate(), calculation);
     } else {
       if (calculation.graph) {
-        node.innerHTML = CalculateApp.libs.mustache.render(getGraphTemplate(), calculation);
+        try {
+          node.innerHTML = CalculateApp.libs.mustache.render(getGraphTemplate(), calculation);
+        } catch (error) {
+          calculation.error=error.message;
+          node.innerHTML = CalculateApp.libs.mustache.render(getErrorTemplate(), calculation);
+          CalculateApp.elements.calcInput.value = '';         
+        }
         var childrens = node.childNodes[0].childNodes;
         var functionGraph = function(input) {
           CalculateApp.graph(input.target.value);
@@ -188,7 +194,13 @@ var CalculateApp = {
           }
         }
       } else {
-        node.innerHTML = CalculateApp.libs.mustache.render(getResultTemplate(), calculation);
+        try {
+          node.innerHTML = CalculateApp.libs.mustache.render(getResultTemplate(), calculation);
+        } catch (e) {
+          calculation.error=e.message;
+          node.innerHTML = CalculateApp.libs.mustache.render(getErrorTemplate(), calculation);
+          CalculateApp.elements.calcInput.value = '';         
+        }
       }
     }
     CalculateApp.elements.resultsZoneDiv.insertBefore(node, CalculateApp.elements.resultsZoneDiv.childNodes[0]);


### PR DESCRIPTION
Fixes #798

This error occurs as inside [`calcEqualClick`](https://github.com/llaske/sugarizer/blob/f489cd323b08a41830426336b7c8a94da191933b/activities/Calculate.activity/js/calculate-activity.js#L188) function only treats `f(x)` as a graph equation and all other as equations to solve. So when we enter any variable other than x it tries to solve it using the [`launchCalculation`](https://github.com/llaske/sugarizer/blob/f489cd323b08a41830426336b7c8a94da191933b/activities/Calculate.activity/js/calculate-activity.js#L162) function instead of the [`launchGraph`](https://github.com/llaske/sugarizer/blob/f489cd323b08a41830426336b7c8a94da191933b/activities/Calculate.activity/js/calculate-activity.js#L132) function and return error when unable to solve it.

In the fix, I have added a check for graph equations in launchCalculation function, if it is a graph equation it will return from the function along with the error in the display. 

Preview:

![Screenshot from 2021-04-20 23-03-25](https://user-images.githubusercontent.com/60233336/115444785-a7ab0680-a232-11eb-8c9e-39995a047f3f.png)
