### PR TITLE
Typo in Step 6 of Vanilla JS Tutorial

### DIFF
--- a/docs/tutorial/VanillaJS/step6.md
+++ b/docs/tutorial/VanillaJS/step6.md
@@ -191,7 +191,7 @@ env.getEnvironment(function(err, environment) {
 	// Set current language to Sugarizer
 	...
 
-	// Load from datatore
+	// Load from datastore
 	if (!environment.objectId) {
 		...
 	}


### PR DESCRIPTION
![a](https://user-images.githubusercontent.com/30799773/157862585-5d4058a7-71a6-4638-a3db-4617d5b9ebaf.PNG)

Fixed a small typo in sugarizer/docs/tutorial/VanillaJS/step6.md on line **194**
[https://github.com/llaske/sugarizer/blob/master/docs/tutorial/VanillaJS/step6.md](url)
`// Load from datatore` 