### PR TITLE
centre aligned pictures

### DIFF
--- a/activities/Abecedarium.activity/styles.css
+++ b/activities/Abecedarium.activity/styles.css
@@ -275,7 +275,6 @@
 .entryImage {
 	width: 70%;
 	margin-top: 5%;
-	margin-left: 10%;
 	text-align: center;
 }
 


### PR DESCRIPTION
fix #1001 

Centre aligned all images. 

Before:
![image](https://user-images.githubusercontent.com/96542494/158749781-b9872f65-4545-4135-8380-6899f7e1d5d1.png)

After:
![image](https://user-images.githubusercontent.com/96542494/158749890-adbbb28e-6203-4892-928e-fba1c157af29.png)
