### PR TITLE
Back button sent back to avoid overlapping

### DIFF
--- a/activities/Tangram.activity/css/activity.css
+++ b/activities/Tangram.activity/css/activity.css
@@ -146,7 +146,6 @@ p {
 	width: 65px;
 	height: 65px;
 	cursor: pointer;
-	z-index: 3;
 }
 
 #spinner {


### PR DESCRIPTION
I have solved the issue about the overlapping of back button with activity palette
Issue: #1058 

<img width="233" alt="s1" src="https://user-images.githubusercontent.com/77184239/163022764-7eeed5b2-921f-4dab-9c24-475f3d9e6a50.png">
<img width="199" alt="s2" src="https://user-images.githubusercontent.com/77184239/163022773-cb5531ac-784e-4db8-b2e3-7c440cce1ef3.png">
