### PR TITLE
In Falabracman activity settings were overlapping with activity palette

### DIFF
--- a/activities/Falabracman.activity/css/activity.css
+++ b/activities/Falabracman.activity/css/activity.css
@@ -56,7 +56,6 @@ body {
   font-size: 20px;
   position: absolute;
   visibility: hidden;
-  z-index: 5;
 }
 
 #main-toolbar #help-button {


### PR DESCRIPTION
I have removed the z-index from settings css so that the `activity-palette` is above the settings text and form.

<img width="436" alt="s5" src="https://user-images.githubusercontent.com/77184239/163026777-de5d3e20-4755-466e-b1af-d37606806cc1.png">
<img width="429" alt="s4" src="https://user-images.githubusercontent.com/77184239/163026796-297e55b9-a28c-4f8a-ae12-35ddc8c7c34a.png">

Issue: #1060 