### PR TITLE
Dictonary not overlapping with background

### DIFF
--- a/activities/Falabracman.activity/css/activity.css
+++ b/activities/Falabracman.activity/css/activity.css
@@ -154,6 +154,9 @@ button.resetEditWord {
 .fontSettingMain {
   font-size: 30px;
 }
+.dictionaryDiv{
+  margin-top: 2.5rem;
+}
 
 @media only screen and (max-height: 550px) {
   #addWord {

--- a/activities/Falabracman.activity/index.html
+++ b/activities/Falabracman.activity/index.html
@@ -47,7 +47,7 @@
 					<div><button type="button" id="resetDict" class="settingButtons fontSettingMain" name="button" title="Reset Dictionary"></button></div>
 				</div>
 			</div>
-			<div>
+			<div id="dictionaryDiv">
 				<div class="fontSettingMain" id="DictHeading"> Dictionary </div>
 				<div id="panel-body">
 					<ul id="dictionary">


### PR DESCRIPTION
Added margin to the `div` containing the ***Dictonary*** in the settings of Falabracman activity so that the word does not overlap with the background image
<img width="766" alt="s7" src="https://user-images.githubusercontent.com/77184239/163029033-c400dbc3-df5d-4916-be70-f8806da78578.png">

Issue: #1062 