### PR TITLE
Fixed Bad handling of multitouch in PhysicsJs.activity

### DIFF
--- a/activities/PhysicsJS.activity/js/activity.js
+++ b/activities/PhysicsJS.activity/js/activity.js
@@ -490,6 +490,10 @@ define(["sugar-web/activity/activity","tutorial","webL10n","sugar-web/env"], fun
 			var createdStart = null;
 			world.on({
 				'interact:poke': function( pos ){
+					// make previously created body dynamic
+					if (createdBody && physicsActive) {
+						createdBody.treatment = "dynamic";
+					}
 					// create body at a static place
 					if (currentType != -1 && pos.y > 55) {
 						createdBody = dropInBody(currentType, pos);


### PR DESCRIPTION
**Fixes** #849 **Multi-touch** issue for both **Play** & **Pause** state.
**Solution**:  make previous body dynamic if not in paused state.

**more explanation**: `'interact:release':` event for bodies will not trigger if multi-touching. so Handle it in `'interact:poke':` event