### PR TITLE
speak activity UI enhancement

### DIFF
--- a/activities/Speak.activity/index.html
+++ b/activities/Speak.activity/index.html
@@ -58,7 +58,7 @@
       <button id="speakText" class="toolbutton" title="Speak"></button>
     </div>
     <input name="idValue" id="idValue" type="hidden">
-		<hr>
+		<hr style="width: 100vw;">
 	</div>
 
   <div style="top:0px;">


### PR DESCRIPTION
hey @llaske
I have updated the code for the Speak activity so that the separator separating the text box and the activity container spreads across the entire width of the screen. Refer to the  issue https://github.com/llaske/sugarizer/issues/1201

![Screenshot (28)](https://user-images.githubusercontent.com/91108730/221633243-900231d0-c6cc-4e94-acf9-f3e0254f03ef.png)
