### PR TITLE
Falabracman Activity intro popup Header text & cross button UI issue solved

### DIFF
--- a/activities/Falabracman.activity/css/introjs.css
+++ b/activities/Falabracman.activity/css/introjs.css
@@ -159,8 +159,8 @@ tr.introjs-showElement>th {
     position: absolute;
     visibility: visible;
     background-color: #fff;
-    min-width: 250px;
-    max-width: 300px;
+    min-width: 320px;
+    max-width: 350px;
     border-radius: 5px;
     -webkit-box-shadow: 0 3px 30px rgba(33, 33, 33, .3);
     box-shadow: 0 3px 30px rgba(33, 33, 33, .3);


### PR DESCRIPTION
hey @llaske 
I have correct the Falabracman activity intro popup header issue.
Refer to issue: https://github.com/llaske/sugarizer/issues/1246

## Before:
![image](https://user-images.githubusercontent.com/96445392/222823157-d91cd8be-7211-468b-b4a6-d4e35c354fc5.png)

## After:
![image](https://user-images.githubusercontent.com/96445392/222823560-f8ecb77c-4a68-4710-a04c-f04fb6c3de6e.png)


