### PR TITLE
Solved Padding Issue In Intro Popups in both ( Abacus Activity and Video Viewer Activity)

### DIFF
--- a/activities/Abacus.activity/css/activity.css
+++ b/activities/Abacus.activity/css/activity.css
@@ -220,7 +220,7 @@ introjs-overlay {
 	text-shadow: none;
 	background-color: #808080;
 	margin: 0;
-	padding: 5px 10px;
+	padding: 0px 10px;
 	border-bottom: 1px solid #ebebeb;
 	border-radius: 5px 5px 0 0;
 }

--- a/activities/VideoViewer.activity/css/activity.css
+++ b/activities/VideoViewer.activity/css/activity.css
@@ -531,7 +531,7 @@ body {
 	text-shadow: none;
 	background-color: #808080;
 	margin: 0;
-	padding: 5px 10px;
+	padding: 0px 10px;
 	border-bottom: 1px solid #ebebeb;
 	border-radius: 5px 5px 0 0;
 }


### PR DESCRIPTION
Hey @llaske I have solved header **Padding issues** in both **Abacus and Video-Viewer activity.** Please review.
**Issue** : https://github.com/llaske/sugarizer/issues/1249

## Snippets
### Before
![image](https://user-images.githubusercontent.com/81116984/222830050-2386278f-d58f-43b7-b463-4bb298e14c25.png)

### After
![image](https://user-images.githubusercontent.com/81116984/222830084-4adaa5d6-65c2-472a-a041-21b2d2455d7f.png)



