### PR TITLE
Mindmath activity overflow issue for screen size 1536x793px solved

### DIFF
--- a/activities/MindMath.activity/css/activity.css
+++ b/activities/MindMath.activity/css/activity.css
@@ -6,6 +6,7 @@ body {
   padding: 0;
   margin: 0;
   box-sizing: border-box;
+  overflow: hidden;
   height: 100vh;
 }
 

--- a/activities/MindMath.activity/css/activity.css
+++ b/activities/MindMath.activity/css/activity.css
@@ -6,7 +6,6 @@ body {
   padding: 0;
   margin: 0;
   box-sizing: border-box;
-  overflow: hidden;
   height: 100vh;
 }
 
@@ -225,6 +224,11 @@ body {
   /* suppress hover effect on devices that don't support hover fully*/
   .btn-general-block:hover {
     background-size: 80%;
+  }
+}
+@media only screen and (min-width: 1200px) {
+  body{
+    overflow: hidden;
   }
 }
 


### PR DESCRIPTION
hey @llaske 
I have solved the overflow issue for Mindmath Activity pls review it.
Refer issue:https://github.com/llaske/sugarizer/issues/1250

## Snippets

Berfore:
![image](https://user-images.githubusercontent.com/96445392/222915916-971e7c1b-3e42-47bf-a6c2-813cb8ace3f1.png)

After:
![image](https://user-images.githubusercontent.com/96445392/222915895-8b5be45f-a2c9-4cc1-9ed8-85c62fb8ce89.png)




