### PR TITLE
header title not Aligned in Ebook Activity

### DIFF
--- a/activities/EbookReader.activity/js/activity.js
+++ b/activities/EbookReader.activity/js/activity.js
@@ -154,7 +154,7 @@ var app = new Vue({
 					<div id='popup-toolbar' class='toolbar' style='padding: 0'>
 						<button class='toolbutton pull-right' id='popup-ok-button' title='`+titleOk+`' style='outline:none;background-image: url(lib/sugar-web/graphics/icons/actions/dialog-ok.svg)'></button>
 						<button class='toolbutton pull-right' id='popup-cancel-button' title='`+titleCancel+`' style='outline:none;background-image: url(lib/sugar-web/graphics/icons/actions/dialog-cancel.svg)'></button>
-						<div style='position: absolute; top: 20px; left: 60px;'>`+titleSettings+`</div>
+						<div style='position: absolute; top: 20px; left: 10px;'>`+titleSettings+`</div>
 					</div>
 					<div id='popup-container' style='width: 100%; overflow:auto'>
 						<div class='popup-label'>`+titleUrl+`</div>


### PR DESCRIPTION
hey @llaske 
I have corrected the alignment for header title in setting popup in Ebook Activity.

## Snippets
---
Before:

![image](https://user-images.githubusercontent.com/96445392/222931433-d2a8533e-4cd1-4e44-8e41-3736d0a70547.png)

After:

![image](https://user-images.githubusercontent.com/96445392/222931437-32d574a5-d99e-4a8f-8637-c6a489990dec.png)

