### PR TITLE
Optimizing Sugarizer Codebase: Removing Unnecessary CSS Code for Improved Performance

### DIFF
--- a/activities/DollarStreet.activity/css/activity.css
+++ b/activities/DollarStreet.activity/css/activity.css
@@ -150,56 +150,7 @@ p {
 	color: #c0c0c0;
 }
 
-.tutorial-icon-button {
-	border-radius: 22px;
-	margin-top: 5px;
-	height: 35px;
-	width: 90px;
-	background-color: #808080;
-	border: 2px solid #808080;
-	display: flex;
-	align-items: center;
-}
 
-.tutorial-icon-button {
-	color: white;
-}
-.tutorial-icon-button.disabled {
-	color: black;
-}
-
-.tutorial-title {
-	background-color: #808080 !important;
-	color: #ffffff !important;
-}
-
-.tutorial-prev-icon1 {
-	margin-left: 6px;
-	background-image: url(../icons/go-left.svg);
-	width: 20px;
-	height: 20px;
-	background-size: 20px 20px;
-}
-
-.tutorial-next-icon1 {
-	margin-left: 6px;
-	background-image: url(../icons/go-right.svg);
-	width: 20px;
-	height: 20px;
-	background-size: 20px 20px;
-}
-
-.tutorial-end-icon1 {
-	margin-left: 6px;
-	background-image: url(../icons/dialog-cancel.svg);
-	width: 20px;
-	height: 20px;
-	background-size: 20px 20px;
-}
-
-.tutorial-icon-text {
-	padding-left: 4px;
-}
 
 .flex-container {
 	display: flex;

--- a/activities/Measure.activity/css/activity.css
+++ b/activities/Measure.activity/css/activity.css
@@ -72,56 +72,6 @@ p {
 	border-radius: 5.5px;
 }
 
-.tutorial-icon-button {
-	border-radius: 22px;
-	margin-top: 5px;
-	height: 35px;
-	width: 90px;
-	background-color: #808080;
-	border: 2px solid #808080;
-	display: flex;
-	align-items: center;
-}
-
-.tutorial-icon-button {
-	color: white;
-}
-.tutorial-icon-button.disabled {
-	color: black;
-}
-
-.tutorial-title {
-	background-color: #808080 !important;
-	color: #ffffff !important;
-}
-
-.tutorial-prev-icon1 {
-	margin-left: 6px;
-	background-image: url(../icons/go-left.svg);
-	width: 20px;
-	height: 20px;
-	background-size: 20px 20px;
-}
-
-.tutorial-next-icon1 {
-	margin-left: 6px;
-	background-image: url(../icons/go-right.svg);
-	width: 20px;
-	height: 20px;
-	background-size: 20px 20px;
-}
-
-.tutorial-end-icon1 {
-	margin-left: 6px;
-	background-image: url(../icons/dialog-cancel.svg);
-	width: 20px;
-	height: 20px;
-	background-size: 20px 20px;
-}
-
-.tutorial-icon-text {
-	padding-left: 4px;
-}
 
 #app {
 	position: fixed;

--- a/activities/Stopwatch.activity/css/activity.css
+++ b/activities/Stopwatch.activity/css/activity.css
@@ -355,10 +355,7 @@ button.remove {
   overflow: hidden;
 }
 
-.tutorial-title{
-  font-weight: bold;
-  line-height: 1.42857143;
-}
+
 
 /* Below code is used to make responsive changes */
 


### PR DESCRIPTION
After My yesterday Pull request https://github.com/llaske/sugarizer/pull/1308 , I tried to review other activities as well During my review, I identified similar instances where CSS code is no longer being used due to the implementation of Intro JS for our tutorials. I strongly believe that removing this unused code is necessary for maintaining the efficiency and readability of the project's codebase.


now I can confidently confirm that after conducting a thorough review of the Sugarizer project, I did not come across any other instances similar to the one that was addressed in my previous and this Pull request. 