### PR TITLE
Hotkey "/" for focusing the Search Field

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -147,4 +147,15 @@ define(["webL10n", "sugar-web/graphics/icon", "sugar-web/graphics/xocolor", "sug
 			loadpreference();
 		}
 	});
+
+	// Hot key "/" to focus search input
+	document.addEventListener('keyup', (event) => {
+		if (event.key === '/') {
+			const searchInput = document.getElementsByClassName('search-field-input');
+			const lastSearchInput = searchInput[searchInput.length - 1];
+			if (lastSearchInput) {
+				lastSearchInput.focus();
+			}
+		}
+	});
 });


### PR DESCRIPTION
I added the hotkey "/" so that it can be used if search bars similar to those we see when we open the settings dialogue box appear in the DOM. If we press the "/" key, the search bar that is being rendered last, i.e. the settings search bar, will then come into focus.  

Refers to #1348 