### PR TITLE
Position of spinner and color of Drop Down Menu changed in QR Code Activity 

### DIFF
--- a/activities/QRCode.activity/css/activity.css
+++ b/activities/QRCode.activity/css/activity.css
@@ -357,11 +357,31 @@
 
 #loading-spinner {
 	position: absolute;
-	margin-left: 30px;
-	margin-top: 10px;
 	visibility: hidden;
 	z-index: 4;
 }
+
+@media (max-width: 1440px) {
+	#loading-spinner {
+		margin-left:23px;
+		margin-top: 60px;
+	}
+}
+
+@media (min-width: 1441px) {
+	#loading-spinner {
+		margin-left:23px;
+		margin-top: 60px;
+	}
+}
+
+@media (max-width: 1140px) {
+	#loading-spinner {
+		margin-left:10px;
+		margin-top: 60px;
+	}
+}
+
 #qrtextdropdown {
 	height: 7vh;
 	width: 7vh;
@@ -370,7 +390,7 @@
 	background-image: url(../icons/go-down.svg);
 	background-size: 55px 50px;
 	background-position: 50% 50%;
-	color: #555;
+	color: #666;
 	font-size: inherit;
 	overflow: hidden;
 	padding-top: 2px;


### PR DESCRIPTION
Fixes issue #1268 

I've matched the color of dropdown with the dropdown image, location of spinner changed and made responsive according to devices

Currently  looks like
![Screenshot 2023-08-15 090856](https://github.com/llaske/sugarizer/assets/116670999/c9dd04aa-828b-4263-9863-aae3da0440f3)

Changed View in QR Code
![Screenshot 2023-08-15 085820](https://github.com/llaske/sugarizer/assets/116670999/2ab758ea-fe8f-4729-901f-5cf500d63657)
![Screenshot 2023-08-15 085804](https://github.com/llaske/sugarizer/assets/116670999/c4d912eb-41d0-4d9d-a413-9bc2f9e83554)

