### PR TITLE
Fixed the error in score in FoodChain Activity

### DIFF
--- a/activities/FoodChain.activity/playgame.js
+++ b/activities/FoodChain.activity/playgame.js
@@ -699,6 +699,8 @@ enyo.kind({
 		this.$.timer.stop();
 		this.$.timerMonster.stop();
 		FoodChain.goHome();
+		FoodChain.context.score = 0;
+		this.$.score.setContent(String("0000"+FoodChain.context.score).slice(-4));	
 		return true; // Prevent event from bubbling up and causing "clickToMove" to be triggered
 	}
 });


### PR DESCRIPTION
Fixes issue #1404 

Made the score to zero in FoodChain Activity, after clicking the home button once a game is finished, so that it doesn't get added up
No error in console

@llaske, could you please review it