### PR TITLE
Fix icon lost its colors on relaunch in Chat activity.

### DIFF
--- a/activities/Chat.activity/index.html
+++ b/activities/Chat.activity/index.html
@@ -19,7 +19,7 @@
 		<div v-cloak id="app">
 			<transition name="fade" appear>
 				<sugar-toolbar ref="SugarToolbar" :class="{fullscreen: isFullscreen}">
-					<sugar-toolitem id="activity-button" :title="l10n.stringTutoExplainTitle"></sugar-toolitem>
+					<sugar-toolitem id="activity-button" title="Chat activity"></sugar-toolitem>
 					<sugar-toolitem
 						id="network-button"
 						title="network"


### PR DESCRIPTION
The problem is when we get a localize title for this icon, it re-renders the icon. This change removes the colorize background-image that was set by ‘sugar-web/activity/activity.js’ on the element itself.

The fix is to not localize title string
