### PR TITLE
disabling canvas pointer events when running intro

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -146,4 +146,19 @@ define(["l10n", "sugar-web/graphics/icon", "sugar-web/graphics/xocolor", "sugar-
 			loadpreference();
 		}
 	});
+
+	// disabling canvas pointer events
+  	document.body.addEventListener("click", function (e) {
+    const isIntrojsElement = document.querySelector(".introjsFloatingElement");
+
+    // if introjsElement is present block all click events in canvas
+    if (isIntrojsElement) {
+    	const canvas = document.getElementById("canvas");
+    	canvas.style.pointerEvents = "none";
+    	console.log("Block click");
+    } else {
+    	canvas.style.pointerEvents = "auto"; // Re-enable click events on the canvas
+    }
+	
+  });
 });

--- a/js/app.js
+++ b/js/app.js
@@ -153,11 +153,10 @@ define(["l10n", "sugar-web/graphics/icon", "sugar-web/graphics/xocolor", "sugar-
 
         // if introjsElement is present block all click events in canvas
         if (isIntrojsElement) {
-		const canvas = document.getElementById("canvas");
-		canvas.style.pointerEvents = "none";
-		console.log("Block click");
+			const canvas = document.getElementById("canvas");
+			canvas.style.pointerEvents = "none";
     	} else {
-		canvas.style.pointerEvents = "auto"; // Re-enable click events on the canvas
+			canvas.style.pointerEvents = "auto"; // Re-enable click events on the canvas
     	}
 	});
 	

--- a/js/app.js
+++ b/js/app.js
@@ -149,16 +149,16 @@ define(["l10n", "sugar-web/graphics/icon", "sugar-web/graphics/xocolor", "sugar-
 
 	// disabling canvas pointer events
   	document.body.addEventListener("click", function (e) {
-    const isIntrojsElement = document.querySelector(".introjsFloatingElement");
+    	const isIntrojsElement = document.querySelector(".introjsFloatingElement");
 
-    // if introjsElement is present block all click events in canvas
-    if (isIntrojsElement) {
-    	const canvas = document.getElementById("canvas");
-    	canvas.style.pointerEvents = "none";
-    	console.log("Block click");
-    } else {
-    	canvas.style.pointerEvents = "auto"; // Re-enable click events on the canvas
-    }
-	
+        // if introjsElement is present block all click events in canvas
+        if (isIntrojsElement) {
+		const canvas = document.getElementById("canvas");
+		canvas.style.pointerEvents = "none";
+		console.log("Block click");
+    	} else {
+		canvas.style.pointerEvents = "auto"; // Re-enable click events on the canvas
+    	}
+		
   });
 });

--- a/js/app.js
+++ b/js/app.js
@@ -159,6 +159,6 @@ define(["l10n", "sugar-web/graphics/icon", "sugar-web/graphics/xocolor", "sugar-
     	} else {
 		canvas.style.pointerEvents = "auto"; // Re-enable click events on the canvas
     	}
-		
-  });
+	});
+	
 });


### PR DESCRIPTION
I've made a small change addressing the issue mentioned in #1418. This pull request aims to dynamically enable or disable click events on the canvas based on the presence of elements with the "introjsFloatingElement" class.

Changes Made:

- Added a click event listener that checks for elements with the "introjsFloatingElement" class.
- When present, click events on the canvas are disabled; otherwise, they're restored.
- This change is intended to provide a smoother user experience by allowing the canvas to respond to "introjsFloatingElement" elements dynamically.

I'd appreciate your review and feedback on these alterations.