### PR TITLE
Fixes#1419:Message_when_namebox_of_user_is_empty

### DIFF
--- a/js/firstscreen.js
+++ b/js/firstscreen.js
@@ -288,6 +288,8 @@ enyo.kind({
 		} else if (this.step == 2) {
 			var name = this.$.name.getValue().trim();
 			if (name.length == 0) {
+				this.$.warningmessage.setContent(l10n.get("ErrorUsernameEmpty"));
+				this.$.warningmessage.setShowing(true);
 				return;
 			}
 

--- a/locale.ini
+++ b/locale.ini
@@ -111,7 +111,6 @@ CopyToShared=Copy to shared
 ByUser=by {{user}}
 Erase=Erase
 ErrorLoadingRemote=Remote server not responding
-ErrorUsernameEmpty=Username is Required
 Retry=Retry
 Server=About my server
 ConnectedToServer=Connected to a server
@@ -395,6 +394,7 @@ ErrorLoadingFileAssignment=Cannot Duplicate the Assignment Entry {{file}}
 SortByDueDate=Sort by due date
 CannotDuplicateAssignment=Cannot duplicate assignment entry
 CannotDeleteAssignment=Cannot delete assignment entry
+ErrorUsernameEmpty=Username is Required
 
 [ar]
 StartNew=بداية جديدة

--- a/locale.ini
+++ b/locale.ini
@@ -111,6 +111,7 @@ CopyToShared=Copy to shared
 ByUser=by {{user}}
 Erase=Erase
 ErrorLoadingRemote=Remote server not responding
+ErrorUsernameEmpty=Username is Required
 Retry=Retry
 Server=About my server
 ConnectedToServer=Connected to a server


### PR DESCRIPTION
I have used same warning component of first screen which is used in case 1 screen for showing ErrorRemoteLoading just used another ErrorUsernameEmpty message in locale.in
![Uploading Screenshot (881).png…]()
