### PR TITLE
Fixed bug preventing pausing when the ball is on the bar

### DIFF
--- a/activities/FractionBounce.activity/js/activity.js
+++ b/activities/FractionBounce.activity/js/activity.js
@@ -135,6 +135,16 @@ let app = new Vue({
 		this.SugarL10n = this.$refs.SugarL10n;
 	},
 
+	watch: {
+		bounceCount: function (newVal) {
+			if (newVal === 0) {
+				this.isFirstPauseClick = true;
+				this.changeGameState();
+				this.isFirstPauseClick = true;
+			}
+		}
+	},
+
 	methods: {
 
 		initialized: function () {
@@ -263,6 +273,7 @@ let app = new Vue({
 				if (this.bounceCount == 0) {
 					this.log = {};
 					this.correctAnswers = 0;
+					this.isFirstPauseClick = true;
 				}
 
 				this.vy = -1 * Math.sqrt(window.innerHeight) / 3.90;

--- a/activities/FractionBounce.activity/js/activity.js
+++ b/activities/FractionBounce.activity/js/activity.js
@@ -33,6 +33,7 @@ let app = new Vue({
 		onSlope: true,
 		SugarL10n: null,
 
+		isFirstPauseClick: true,
 		frameInterval: 20,
 		launchDelay: 1000,
 		height: 100,
@@ -110,6 +111,10 @@ let app = new Vue({
 			} else {
 				return this.l10n.stringHelpBounceToPosition + ' ' + this.answer + "/" + this.parts + ' ' + this.l10n.stringHelpOfTheWay;
 			}
+		},
+
+		isPauseAvailable: function () {
+			return !this.onSlope || this.isFirstPauseClick;
 		}
 	},
 
@@ -227,12 +232,12 @@ let app = new Vue({
 		},
 
 		changeGameState: function () {
-			if (this.onSlope && this.bounceCount > 0) {
-				// If the condition is true, do not allow pausing
+			if (this.isPauseAvailable) {
+				this.paused = !this.paused;
+			} else {
 				return;
 			}
 
-			this.paused = !this.paused;
 			if (!this.paused) {
 				this.launch();
 				if(this.count==30){
@@ -241,6 +246,11 @@ let app = new Vue({
 			        Score.innerHTML = " ";	
 				}
 			}
+
+			if (this.isFirstPauseClick) {
+				this.isFirstPauseClick = false;
+			}
+
 			document.getElementById('slopeCanvas').removeEventListener('click', this.startGame);
 		},
 

--- a/activities/FractionBounce.activity/js/activity.js
+++ b/activities/FractionBounce.activity/js/activity.js
@@ -227,6 +227,11 @@ let app = new Vue({
 		},
 
 		changeGameState: function () {
+			if (this.onSlope && this.bounceCount > 0) {
+				// If the condition is true, do not allow pausing
+				return;
+			}
+
 			this.paused = !this.paused;
 			if (!this.paused) {
 				this.launch();


### PR DESCRIPTION
Fixes #1511

This pull request addresses a bug that allowed players to pause the game while the ball was on the slope, leading to unintended behavior and allowing exploitation of the game mechanics to bypass the maximum turn limit.

The fix introduces a condition to disable the pause functionality when the ball is on the bar after the first round, ensuring that players cannot pause the game during critical moments of gameplay.

@llaske 
![Screenshot_20240128_084807](https://github.com/llaske/sugarizer/assets/91102592/3b0d0aa5-1d48-4a97-b375-c8b69573fe04)
