### PR TITLE
fix: Mazeweb.activity sometimes having player without face.

### DIFF
--- a/activities/MazeWeb.activity/js/activity.js
+++ b/activities/MazeWeb.activity/js/activity.js
@@ -37,9 +37,7 @@ define(["sugar-web/activity/activity","tween","rAF","activity/directions","sugar
             }
 
             // Load from datastore
-            if (!environment.objectId) {
-                runLevel();
-            } else {
+            if (environment.objectId) {
                 activity.getDatastoreObject().loadAsText(function(error, metadata, data) {
                     if (error==null && data!=null) {
                         data = JSON.parse(data);
@@ -475,6 +473,7 @@ define(["sugar-web/activity/activity","tween","rAF","activity/directions","sugar
 
         var nextLevel = function () {
             gameSize *= 1.2;
+            dirtyCells = [];
             runLevel();
         }
 
@@ -644,6 +643,7 @@ define(["sugar-web/activity/activity","tween","rAF","activity/directions","sugar
         var restartButton = document.getElementById('restart-button');
         restartButton.addEventListener('click', function(e) {
             gameSize = 60;
+            dirtyCells = [];
             runLevel();
         });
 


### PR DESCRIPTION
- The Unexpected behaviour mentioned in issue #1536 occurs randomly it's not related to restarting the activity or anything.

- The behaviour is due to calling `runLevel` function several times without clearing the `dirtyCells` array/state.
- if we call `runLevel` again and `dirtyCells` still have some cells left to draw from previous level, it'll try to draw it in another level.

- I also reproduced the unexpected behaviour by setting `maze.goalPoint` to same as `maze.startPoint` (which was in actual code happening randomly) and then with `setTimeout` changing the `goalPoint` again.


https://github.com/llaske/sugarizer/assets/90092555/5efe0905-6a90-4b62-9f4c-c1737e7852c8

