### PR TITLE
Added functionality to close palette when clicking outside

### DIFF
--- a/activities/Fototoon.activity/lib/sugar-web/graphics/palette.js
+++ b/activities/Fototoon.activity/lib/sugar-web/graphics/palette.js
@@ -180,6 +180,18 @@ define(function () {
         }
     };
 
+    // Event listener to close the palette when clicking outside the area
+    document.addEventListener('click', function (event) {
+        for (var i = 0; i < palettesGroup.length; i++) {
+            var palette = palettesGroup[i];
+            var paletteElem = palette.getPalette();
+            var invokerElem = palette.invoker;
+            if (!paletteElem.contains(event.target) && event.target !== invokerElem) {
+                palette.popDown();
+            }
+        }
+    });
+    
     return palette;
 
 });


### PR DESCRIPTION
Palette closes when clicked outside now

![ezgif-7-c2224955d0](https://github.com/llaske/sugarizer/assets/64434937/74694363-2d35-4b95-aa3a-e24f7da2b5ef)

This can be done for all activities, what do you say @llaske ?