### PR TITLE
Fix: defeat music stops correctly during navigation.

### DIFF
--- a/activities/TankOp.activity/play.js
+++ b/activities/TankOp.activity/play.js
@@ -330,11 +330,7 @@ enyo.kind({
 
 			// Back to app
 			app.renderInto(document.getElementById("board"));
-		}
-		if(this.endOfGame){
-			if(app.renderInto(document.getElementById("board"))){
-				sound.pause();
-			}
+			sound.pause();
 		}
 
 		// Compute direction

--- a/activities/TankOp.activity/play.js
+++ b/activities/TankOp.activity/play.js
@@ -57,7 +57,6 @@ enyo.kind({
 	create: function() {
 		this.inherited(arguments);
 		play = this;
-		pause = this;
 		this.imagesToLoad++;
 		this.endOfGame = false;
 		this.pausedGame = true;

--- a/activities/TankOp.activity/play.js
+++ b/activities/TankOp.activity/play.js
@@ -57,6 +57,7 @@ enyo.kind({
 	create: function() {
 		this.inherited(arguments);
 		play = this;
+		pause = this;
 		this.imagesToLoad++;
 		this.endOfGame = false;
 		this.pausedGame = true;
@@ -330,6 +331,11 @@ enyo.kind({
 
 			// Back to app
 			app.renderInto(document.getElementById("board"));
+		}
+		if(this.endOfGame){
+			if(app.renderInto(document.getElementById("board"))){
+				sound.pause();
+			}
 		}
 
 		// Compute direction


### PR DESCRIPTION
The defeat music in the Tank Operation activity persists even after returning to a previous screen. This PR resolves the issue by ensuring that the defeat music stops correctly during navigation.
here is how I solve this issue:
by using the if statement i.e if the game ends && the screen is also changed then the sound will pause 
Activity name: Tank-operation.
Issue: #1553 
@llaske please review this PR.