### PR TITLE
Moon activity: css fix in chrome mobile version

### DIFF
--- a/activities/Moon.activity/css/activity.css
+++ b/activities/Moon.activity/css/activity.css
@@ -181,3 +181,15 @@ canvas {
 	background-color: #808080;
 	border: 2px solid #808080;
 }
+@media only screen and (max-width: 600px) {
+    #panel-container{
+        display: flex;
+        flex-direction: column-reverse;
+    }
+    #panel-left{
+        width: 100%;
+    }
+    #panel-right{
+        width: 100%;
+    }
+  }


### PR DESCRIPTION
Issue reference: #1576 

Before fix:
<img width="1703" alt="Screenshot 2024-03-28 at 8 08 57 PM" src="https://github.com/llaske/sugarizer/assets/95471286/d2f0b190-7f40-4a2b-9abb-b748aa9f46e9">

After fix:
<img width="1710" alt="Screenshot 2024-03-29 at 1 29 13 AM" src="https://github.com/llaske/sugarizer/assets/95471286/bf8a579b-ef51-41d2-90cd-b10294d494ae">



Kindly review it.
@llaske 
