### PR TITLE
Added functionality to undo and redo using the keyboard in the Paint Activity

### DIFF
--- a/activities/Paint.activity/js/buttons/redo-button.js
+++ b/activities/Paint.activity/js/buttons/redo-button.js
@@ -6,6 +6,11 @@ define([], function () {
   function initGui() {
     var redoButton = document.getElementById('redo-button');
     PaintApp.elements.redoButton = redoButton;
+    document.querySelector("body").addEventListener("keydown", (event)=> {
+      if(event.key == "y" && event.ctrlKey == true) {
+        redo();
+      }
+    })
     redoButton.addEventListener('click', redo);
   }
   function hideGui() {

--- a/activities/Paint.activity/js/buttons/undo-button.js
+++ b/activities/Paint.activity/js/buttons/undo-button.js
@@ -7,6 +7,11 @@ define([], function() {
   function initGui() {
     var undoButton = document.getElementById('undo-button');
     PaintApp.elements.undoButton = undoButton;
+    document.querySelector("body").addEventListener("keydown", (event)=> {
+      if(event.key == "z" && event.ctrlKey == true) {
+        redo();
+      }
+    })
     undoButton.addEventListener('click', undo);
   }
 


### PR DESCRIPTION
Added the functionality to undo by pressing ctrl and 'z' on the keyboard and redo pressing ctrl and 'y'. I believe this can be done for all the activites supporting undo and redo buttons as it an intuitive way to do these actions and is common everywhere.
What do you think @llaske ?

[screen-capture (2).webm](https://github.com/llaske/sugarizer/assets/69239707/d71c3830-143a-470b-a577-76de21092c07)
