### PR TITLE
Increasing the drop speed of the ball on pressing arrow down

### DIFF
--- a/activities/FractionBounce.activity/js/activity.js
+++ b/activities/FractionBounce.activity/js/activity.js
@@ -560,6 +560,11 @@ let app = new Vue({
 					case 39:
 						this.vx += 10;
 						break;
+					case 40:
+						if (this.vy < 4.5) {
+							this.vy += 1;
+						}
+						break;
 				}
 			}
 			setTimeout(function () {


### PR DESCRIPTION
#1591 
Added the functionality for users to press arrow down to increase the speed of the ball coming down as sometimes the user is able to bring the ball to the appropriate point but has to wait for the ball to come down. Here is how it looks -

[screen-capture (7).webm](https://github.com/llaske/sugarizer/assets/69239707/f7362c6a-6615-4ed5-8f48-3fed9dd0cd64)

I have put a check so that the speed of the ball does'nt exceed a certain point as, if the speed is very high the ball bounces up very far. What do you think @llaske ?