### PR TITLE
 LabyrinthJS: Idea selection-indicator while linking ideas

### DIFF
--- a/activities/LabyrinthJS.activity/js/activity.js
+++ b/activities/LabyrinthJS.activity/js/activity.js
@@ -362,11 +362,18 @@ define(["sugar-web/activity/activity", "l10n", "sugar-web/datastore", "sugar-web
 				if (lastSelected == this) lastSelected = null;
 				return;
 			} else if (currentMode == 1) {
+				if (isSelectedNode(this)) {
+					unselectNode(this);
+					lastSelected = null;
+				}
+				else { selectNode(this); }
 				if (lastSelected != null && lastSelected != this) {
 					createEdge(lastSelected, this);
+					unselectNode(this);
+					lastSelected = null;
 					pushState();
 				}
-				lastSelected = this;
+				if (isSelectedNode(this)) lastSelected = this;
 				return;
 			} else {
 				if (isSelectedNode(this)) {


### PR DESCRIPTION
While linking ideas, no selection-indicator of selected idea was visible thereby creating confusion. Added a selection-indicator to the currently selected idea and auto-deselect after making a link.