### PR TITLE
Fototoon svg alignment to text in warning box

### DIFF
--- a/activities/Fototoon.activity/css/activity.css
+++ b/activities/Fototoon.activity/css/activity.css
@@ -406,6 +406,8 @@ background-size: 100% 1.2em;
 @media screen and (min-width: 775px)
   {
     .warningbox-cancel-button {
+      display: flex;
+      align-items: center;
 	    position: absolute;
       right: 240px;
       width: 210px;
@@ -416,6 +418,8 @@ background-size: 100% 1.2em;
       font-size:15px;
     }
     .warningbox-refresh-button {
+      display: flex;
+      align-items: center;
       position: absolute;
       right: 10px;
       width: 210px;
@@ -430,6 +434,8 @@ background-size: 100% 1.2em;
 @media screen and (max-width: 774px)
   {
     .warningbox-cancel-button {
+      display: flex;
+      align-items: center;
 	    position: absolute;
       right: 170px;
       width: 160px;
@@ -439,6 +445,8 @@ background-size: 100% 1.2em;
       font-size:15px;
   }
   .warningbox-refresh-button {
+    display: flex;
+      align-items: center;
     position: absolute;
     right: 10px;
     width: 140px;


### PR DESCRIPTION
#1596 @llaske The Cancel and Continue button is now aligned to the icon.
![Screenshot from 2024-04-13 10-09-23](https://github.com/llaske/sugarizer/assets/125907752/64e1f117-fdcb-452b-933c-60060b43c339)
