### PR TITLE
Pallette pops down when something is cliked in Dollar Street Activity

### DIFF
--- a/activities/DollarStreet.activity/js/palettes/incomes.js
+++ b/activities/DollarStreet.activity/js/palettes/incomes.js
@@ -34,6 +34,10 @@ define(['sugar-web/graphics/palette',"text!activity/palettes/incomes.html"], fun
 			that.getPalette().dispatchEvent(that.incomeEvent);
 		});
 
+		document.querySelector('#content').addEventListener('click', function(event){
+			that.popDown();
+		});	
+
 		let wrapper = this.getPalette().childNodes[1];
 		wrapper.style.width = "450px";
 		wrapper.style.maxWidth = "400px";

--- a/activities/DollarStreet.activity/js/palettes/regions.js
+++ b/activities/DollarStreet.activity/js/palettes/regions.js
@@ -61,6 +61,10 @@ define(["sugar-web/graphics/palette"], function(palette) {
 		that.getPalette().firstChild.style.backgroundColor = "transparent";
 		that.getPalette().firstChild.style.backgroundImage = "";
 
+		document.querySelector('#content').addEventListener('click', function(event){
+			that.popDown();
+		});	
+
 		function popDownOnButtonClick(event) {
 			console.log(event);
 			that.popDown();

--- a/activities/DollarStreet.activity/js/palettes/things.js
+++ b/activities/DollarStreet.activity/js/palettes/things.js
@@ -55,6 +55,10 @@ define(["sugar-web/graphics/palette"], function(palette) {
 		that.getPalette().firstChild.style.backgroundColor = "transparent";
 		that.getPalette().firstChild.style.backgroundImage = "";
 
+		document.querySelector('#content').addEventListener('click', function(event){
+			that.popDown();
+		});	
+
 		function popDownOnButtonClick(event) {
 			console.log(event);
 			that.popDown();


### PR DESCRIPTION
Fixes #1605 
Now all pallettes in the Dollar Street Activity pop down when anything is clicked.

Demo-

[screen-capture (20).webm](https://github.com/llaske/sugarizer/assets/69239707/7aa7de47-04dc-4913-a529-b45f76df3e19)
