### PR TITLE
Fixes the error in the tutorial of the Food Chain activity

### DIFF
--- a/activities/FoodChain.activity/js/activity.js
+++ b/activities/FoodChain.activity/js/activity.js
@@ -49,6 +49,9 @@ define(["sugar-web/activity/activity","l10n","sugar-web/graphics/radiobuttonsgro
 					} else if (language == 'pt') {
 						l10n.language.code = "pt_BR";
 						l10n.init("pt_BR");
+					} else{
+						l10n.language.code = "en";
+						l10n.init("en");
 					}
 
 					// Init sound component


### PR DESCRIPTION
Fixes #1608
I have added english as a fallback language for when a language that does not have a translation json file is selected.