### PR TITLE
[v2] Increased code coverage in icon.js file

### DIFF
--- a/v2/tests/icon.spec.js
+++ b/v2/tests/icon.spec.js
@@ -213,4 +213,54 @@ describe('Icon.vue', () => {
 		expect(wrapper.vm._element.getAttribute("width")).toBe('55px');
 		expect(wrapper.vm.$refs.icon.getAttribute("style")).toBe('margin: 0px 0px 0px 0px;--stroke-color:#000000;--fill-color:#999999;');
 	});
+
+	it('should set color correctly', async () => {
+        wrapper = mount(Icon, {
+            props: { 
+                id: id,
+                svgfile: svgfileNew,
+                color: 180,
+                size: size,
+                x: x,
+                y: y,
+                isNative: isSugarNative
+            },
+        })
+        await delay(1000);
+        expect(wrapper.vm._element.getAttribute("class")).toBe('xo-color0');
+    });
+
+    it('should set size correctly', async () => {
+        wrapper = mount(Icon, {
+            props: { 
+                id: id,
+                svgfile: svgfileNew,
+                color: color,
+                size: 200,
+                x: x,
+                y: y,
+                isNative: isSugarNative
+            },
+        })
+        await delay(1000);
+        expect(wrapper.vm._element.getAttribute("width")).toBe('200px');
+        expect(wrapper.vm._element.getAttribute("height")).toBe('200px');
+    });
+
+    it('should check if cursor is inside the icon component correctly', async () => {
+        wrapper = mount(Icon, {
+            props: { 
+                id: id,
+                svgfile: svgfileNew,
+                color: color,
+                size: size,
+                x: x,
+                y: y,
+                isNative: isSugarNative
+            },
+        })
+        await delay(1000);
+        expect(wrapper.vm.isCursorInside(x + size / 2, y + size / 2)).toBe(true);
+        expect(wrapper.vm.isCursorInside(x - 1, y - 1)).toBe(false);
+    });
 })


### PR DESCRIPTION
Increased the test coverage of  icon.js file in v2

Before
![Screenshot 2024-04-29 192908](https://github.com/llaske/sugarizer/assets/116670999/f6e10602-ce9f-43d7-8b13-ca5885d0f0eb)


After 
![Screenshot 2024-04-29 192252](https://github.com/llaske/sugarizer/assets/116670999/2bbf4b48-0aa2-4579-a3b1-ca8281717b8d)

@llaske, could you please review it