### PR TITLE
fixup! resolving mentor reviews

### DIFF
--- a/v2/js/screens/listview.js
+++ b/v2/js/screens/listview.js
@@ -58,7 +58,7 @@ const ListView = {
 							<div class="clearSearchField" @click="clearSearchField">
 								<div>
 									{{ SugarL10n.get("ClearSearch") }}
-								<div>
+								</div>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
It fixes an issue caused here https://github.com/llaske/sugarizer/commit/eb495606585e2cec6399cc1a1fc9b5c3078e8edd?diff=unified&w=1#diff-f461fe8943e93f6ea344fd18e8f6dde779b1fe0cfd8fa629e5888aa29dad6a2fR57

which is responsible to break the listview popup hovering