### PR TITLE
Fix i18next not exporting language.

### DIFF
--- a/v2/js/modules/i18next.js
+++ b/v2/js/modules/i18next.js
@@ -61,5 +61,5 @@ define(["lib/i18next.min.js", "lib/i18next-vue.js"], function (
 		app.use(I18NextVue, { i18next });
 	};
 
-	return { init, useI18n };
+	return { init, useI18n, language };
 });


### PR DESCRIPTION
After some debugging i found that the user.js module needs to access the language from i18next while signing up the user, which the module i18next is not exporting
Here https://github.com/llaske/sugarizer/blob/feature/v2/v2/js/modules/user.js#L100

Fixes #1639