### PR TITLE
Fix: Listview popup increasing page length (issue : #1674)

### DIFF
--- a/js/popup.js
+++ b/js/popup.js
@@ -95,9 +95,15 @@ enyo.kind({
 			// Popup will overflow window, prepare to shift menu
 			this.overflowY = true;
 		}
+		var screenHeight = document.getElementById("canvas").offsetHeight;
+		var popupTopPosition = mouse.position.y + this.margin.top;
+		var popupBottomPosition = mouse.position.x + this.margin.left;
+		if (mouse.position.y + popupSize > screenHeight) {
+			popupTopPosition = screenHeight+this.margin.top-popupSize;
+		}
 		this.setStyle("bottom", "");
-		this.applyStyle("top", (mouse.position.y+this.margin.top)+"px");
-		this.applyStyle("left", (mouse.position.x+this.margin.left)+"px");
+		this.applyStyle("top", (popupTopPosition) + "px");
+		this.applyStyle("left", (popupBottomPosition) + "px");
 		this.show();
 		this.timer = window.setInterval(enyo.bind(this, "showContent"), 0);
 	},


### PR DESCRIPTION
The pr is a fix to issue : #1674. Added line in `js/popup.js` preventing the popup in listview from increasing the page length for bottom icons and going out of page height for lower icons on screen.

Demonstration : 
[Screencast from 2024-12-10 23-42-58.webm](https://github.com/user-attachments/assets/7b50ae2d-1bf7-4647-a410-b5fcf80d509b)
