### PR TITLE
Picture of frog and rocks is sometimes incomplete in Foodchain activity 

### DIFF
--- a/activities/FoodChain.activity/playgame.js
+++ b/activities/FoodChain.activity/playgame.js
@@ -624,6 +624,11 @@ enyo.kind({
 			this.frog.useImage(0);
 			this.frog.draw(this.ctx);
 			this.frog.alive = true;
+			// Undraw and redraw all the rocks
+			for (var i = 0; i < this.rocks.length; i++) {
+				this.rocks[i].unDraw(this.ctx);  // Clear the rock from the canvas
+				this.rocks[i].draw(this.ctx);    // Redraw the rock in its original position
+			}
 			return;
 		}
 

--- a/activities/FoodChain.activity/playgame.js
+++ b/activities/FoodChain.activity/playgame.js
@@ -312,6 +312,11 @@ enyo.kind({
 
 		// Move frog
 		this.frog.unDraw(this.ctx);
+		// Undraw and redraw all the rocks
+		for (var i = 0; i < this.rocks.length; i++) {
+			this.rocks[i].unDraw(this.ctx);  // Clear the rock from the canvas
+			this.rocks[i].draw(this.ctx);    // Redraw the rock in its original position
+		}
 		if (newHeading != this.frog.getHeading()) {
 			// Just change heading
 			this.frog.setHeading(newHeading);
@@ -446,6 +451,8 @@ enyo.kind({
 		currentfly.setY(dummyfly.getY());
 		currentfly.setHeading(dummyfly.getHeading());
 		currentfly.draw(this.ctx);
+		this.frog.unDraw(this.ctx);
+		this.frog.draw(this.ctx);
 		currentfly.playSound();
 	},
 


### PR DESCRIPTION
### Fix to issue : #1191 

**Issues:**
- Picutre of frog is sometimes incomplete when overlapping with other images.
- On collision of frog with rock erases some parts of the rock making the image of rock as incomplete.

**Fix:**
Whenever the frog collides with a rocks they rocks are erased from canvas and redrawn.
Whenever the frog and flies overlap frog is redrawn.
