### PR TITLE
Resize images in fototoon

### DIFF
--- a/activities/Fototoon.activity/js/activity.js
+++ b/activities/Fototoon.activity/js/activity.js
@@ -109,7 +109,7 @@ define(["sugar-web/activity/activity","sugar-web/datastore","sugar-web/env","tex
 						element.src = text;
 					}
 					element.onload = function () {
-						toonModel.addImage(element.src);
+                        toonModel.addGlobe(toon.TYPE_IMAGE,element.src)
 					};
 				});
 			}, { mimetype: 'image/png' }, { mimetype: 'image/jpeg' }, { activity: 'org.olpcfrance.PaintActivity'});


### PR DESCRIPTION
Fix : #1551

Earlier the images were set as background image to the whole canvas as a result they were not resizable. 
In this fix i have made the images as a sperate globe which is resizable.

After fix:
https://github.com/user-attachments/assets/defadbed-dcb0-4ec7-90b4-6d807a7bf45e



