### PR TITLE
Fix: Intraction with sign up breaks sign up tutorial

### DIFF
--- a/lib/tutorial.js
+++ b/lib/tutorial.js
@@ -18,13 +18,13 @@ define([], function () {
 		var gotoStep = undefined;
 		tutorial.activityId = null;
 		tour = introJs().setOptions({
-				tooltipClass: 'customTooltip',
-				prevLabel: prevString,
-				nextLabel: nextString,
-				exitOnOverlayClick: false,
-				nextToDone: false,
-				showBullets: false,
-                                disableInteraction: true,
+			tooltipClass: 'customTooltip',
+			prevLabel: prevString,
+			nextLabel: nextString,
+			exitOnOverlayClick: false,
+			nextToDone: false,
+			showBullets: false,
+			disableInteraction: true,
 		});
 		tour.onafterchange(function() {
 			var color = this._introItems[this._currentStep].iconColor;

--- a/lib/tutorial.js
+++ b/lib/tutorial.js
@@ -23,7 +23,8 @@ define([], function () {
 				nextLabel: nextString,
 				exitOnOverlayClick: false,
 				nextToDone: false,
-				showBullets: false
+				showBullets: false,
+                                disableInteraction: true,
 		});
 		tour.onafterchange(function() {
 			var color = this._introItems[this._currentStep].iconColor;


### PR DESCRIPTION
# Hello, this is my first contribution to Sugar Labs! 

This pull request addresses **Issue #1418**:  


*Intro.js breaks when the "Sign Up" button is pressed during the tutorial.*

I reviewed the closed PR for this issue, where it was mentioned that disabling canvas mouse events was considered too complex a solution. To approach this differently, I explored the Intro.js documentation and found a simpler alternative: the `disableInteraction` option. By setting this option to `true`, the issue is resolved effectively.

You can find more details in the [Intro.js documentation](https://introjs.com/docs/tour/examples/disable-interaction)

I’d love to hear your feedback. Please let me know if further changes are needed. 

Thank you! 😊

# DEMO

[Screencast from 2025-01-05 13-43-36.webm](https://github.com/user-attachments/assets/b5d88947-04b5-4e48-bcf9-1c80c57521e8)