### PR TITLE
Initialized sample values in chart activity

### DIFF
--- a/activities/Chart.activity/js/activity.js
+++ b/activities/Chart.activity/js/activity.js
@@ -22,6 +22,8 @@ const app = new Vue({
 		"csv-view": CsvView,
 	},
 	data: {
+		isLocalized: false,
+		pendingNewInstance: false,
 		currentenv: null,
 		SugarL10n: null,
 		SugarPresence: null,
@@ -145,9 +147,15 @@ const app = new Vue({
 			});
 		},
 		localized() {
+			this.isLocalized = true;
 			this.SugarL10n.localize(this.l10n);
 			document.getElementById("export-csv-button").title = this.l10n.stringexportAsCSV;
 			document.getElementById("export-img-button").title = this.l10n.stringSaveImage;
+			// If onJournalNewInstance was triggered before localization
+			if (this.pendingNewInstance) {
+				this.onJournalNewInstance(); // Execute the pending call
+				this.pendingNewInstance = false;
+			}
 
 		},
 
@@ -270,6 +278,10 @@ const app = new Vue({
 
 
 		onJournalNewInstance() {
+			if (!this.isLocalized) {
+				this.pendingNewInstance = true; // Mark the call as pending
+				return;
+			}
 			const randArr = this.shuffleArray([1, 2, 3, 4, 5, 6]);
 			for(let i = 0; i < 3; i++) {
 				const label = "EgLabel" + randArr[i];


### PR DESCRIPTION
Fix to issue: #1695 

Issue: The problem occurs because the sample values are not localized if the onJournalNewInstance function is triggered before the localization process. As a result, the function returns default values (e.g., EgLabelX), which are not in the localized format.

Fix: To resolve this issue, the onJournalNewInstance function is triggered after the localization process. This ensures that all sample values are correctly localized before they are used, preventing the default values (e.g., EgLabelX) from being used.

https://github.com/user-attachments/assets/1c0a9bc5-76db-4159-9c37-a041be2b9a78





