### PR TITLE
En passant Highlight Implemented

### DIFF
--- a/activities/Chess.activity/js/chessGame.js
+++ b/activities/Chess.activity/js/chessGame.js
@@ -508,7 +508,7 @@ var ChessGame = {
       // get list of possible moves for this square
       var moves = [];
       p4_prepare(this.state);
-      var allMoves = p4_parse(this.state, this.state.to_play, undefined, 0);
+      var allMoves = p4_parse(this.state, this.state.to_play,this.state.enpassant, 0);
 
       for (var i = 0; i < allMoves.length; i++) {
         if (p4_stringify_point(allMoves[i][1]) == square) {


### PR DESCRIPTION
Fixes #1707 

It highlights now en-passant Square 

https://github.com/user-attachments/assets/7b6a27bf-9e7d-465d-aaab-adc3717df210



After checking so many conditions I found the issue lies in parsing the p4_parse Function undefined was passed instead of En-passant state