### PR TITLE
Fix : Failed to download: resources/resources/etoys.image

### DIFF
--- a/activities/Etoys.activity/index.html
+++ b/activities/Etoys.activity/index.html
@@ -27,13 +27,16 @@ THE SOFTWARE.
 <script src="squeak.min.js"></script>
 <script>
 window.onload = function() {
-    SqueakJS.runSqueak("resources/etoys.image", sqCanvas, {
+    SqueakJS.runSqueak("etoys.image", sqCanvas, {
         appName: "Etoys",
         fixedWidth: 1200,
         fixedHeight: 900,
         fullscreen: true,
         spinner: sqSpinner,
-        files: ["etoys.changes", "EtoysV5.stc"],
+        files: [
+            "resources/etoys.changes",
+            "resources/EtoysV5.stc"
+        ],
         root: "/Etoys",
         templates: { "/Etoys": "resources" },
         onQuit: function() {


### PR DESCRIPTION
Fixes:  #1717

Applied fix:
- Fixed file path to fix the failed to download issue.

Before:
![image](https://github.com/user-attachments/assets/adc5f623-bd30-40a6-bb32-baed2f862146)


After: 

https://github.com/user-attachments/assets/ee446e21-725f-40d5-8acb-6d6ce8436d11


