### PR TITLE
Deploy to dev.sugarizer.org only from main repo not forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-and-deploy:
+    if: github.repository == 'llaske/sugarizer'
     runs-on: ubuntu-latest
     steps:
       - name: Deploy on Sugarizer Dev Server


### PR DESCRIPTION
I noticed [my own fork tried to _build-and-deploy_](https://github.com/codefrau/sugarizer/actions/runs/13423087721), which of course does not work.

This PR ensures that only your own repo gets pushed to the dev server, not forks.