### PR TITLE
Bug Fixed : Jappy Activity initial render

### DIFF
--- a/activities/Jappy.activity/js/codeeditor.js
+++ b/activities/Jappy.activity/js/codeeditor.js
@@ -1562,7 +1562,7 @@ function init() {
             }
             if (len(window.files) > 0) {
                 tag.title = list(parsed_data)[0];
-                editor.swapDoc((ρσ_expr_temp = window.files)[ρσ_bound_index(tag.title, ρσ_expr_temp)]);
+                editor.setValue((ρσ_expr_temp = window.files)[ρσ_bound_index(tag.title, ρσ_expr_temp)]);
                 editor.setOption("mode", "python");
             }
             tag.update();


### PR DESCRIPTION
Gone through the bug and referred CodeMirror API to solve the issue 
The issue was in proper using of CoderMirror functions
It was using swapDoc instead of setValue , therefore the code was rendering/mirroring on screen when we click on the tab 

Fixes #1738 

