### PR TITLE
Fix: Incorrect Total Dice Value Subtraction

### DIFF
--- a/activities/3DVolume.activity/js/activity.js
+++ b/activities/3DVolume.activity/js/activity.js
@@ -670,13 +670,23 @@ define([
 
 		// Adds all the numbers on top for the numbered volumes.
 		function updateElements() {
-			lastRollElement.textContent =
-				scoresObject.lastRoll.substring(
-					0,
-					scoresObject.lastRoll.length - 2
-				) +
-				"= " +
-				scoresObject.presentScore;
+			if (!scoresObject.lastRoll || scoresObject.lastRoll === "") {
+				lastRollElement.textContent = "";
+				return;
+			}
+			
+			let displayString = scoresObject.lastRoll;
+			// Trim trailing " + " if present
+			if (displayString.endsWith(" + ")) {
+				displayString = displayString.substring(0, displayString.length - 3);
+			}
+			
+			// Only show score if we have valid dice scores
+			if (displayString) {
+				lastRollElement.textContent = displayString + " = " + scoresObject.presentScore;
+			} else {
+				lastRollElement.textContent = "";
+			}
 		}
 
 		const renderer = new THREE.WebGLRenderer({
@@ -838,6 +848,20 @@ define([
 
 				remove(intersectedObject);
 			}
+		}
+		// Check if a die is not moving -> sleeping
+		function isDiceSleeping(dice) {
+			return dice[1].sleepState === CANNON.Body.SLEEPING;
+		}
+
+		// Check if we have any scored dice -> stationary numbered dice
+		function hasAnyScoredDice() {
+			for (let i = 0; i < diceArray.length; i++) {
+				if (diceArray[i][3] && isDiceSleeping(diceArray[i])) {
+					return true;
+				}
+			}
+			return false;
 		}
 		function remove(intersectedObject, index) {
 			let num = 0;
@@ -1004,7 +1028,8 @@ define([
 					}
 				}
 			}
-			if (num == 0) {
+			// Update display - hide score if no scored dice remain
+			if (num == 0 || !hasAnyScoredDice()) {
 				lastRollElement.textContent = "";
 				scoresObject.lastRoll = "";
 				scoresObject.presentScore = 0;

--- a/activities/3DVolume.activity/js/activity.js
+++ b/activities/3DVolume.activity/js/activity.js
@@ -841,6 +841,13 @@ define([
 		}
 		function remove(intersectedObject, index) {
 			let num = 0;
+
+			//to ensure scores are updated before removal
+			if (world.hasActiveBodies === false && throwingDice) {
+				getScores();
+				throwingDice = false;
+			}
+
 			for (let i = 0; i < diceArray.length; i++) {
 				if (diceArray[i][3]) {
 					num++;
@@ -1466,6 +1473,7 @@ define([
 			if (diceArray.length > 0) {
 				scoresObject.lastRoll = "";
 				scoresObject.presentScore = 0;
+				updateElements();
 				for (let i = 0; i < diceArray.length; i++) {
 					diceArray[i][1].angularVelocity.set(
 						diceArray[i][7],

--- a/activities/3DVolume.activity/js/activity.js
+++ b/activities/3DVolume.activity/js/activity.js
@@ -841,21 +841,17 @@ define([
 		}
 		function remove(intersectedObject, index) {
 			let num = 0;
-
-			//to ensure scores are updated before removal
-			if (world.hasActiveBodies === false && throwingDice) {
-				getScores();
-				throwingDice = false;
-			}
-
 			for (let i = 0; i < diceArray.length; i++) {
 				if (diceArray[i][3]) {
 					num++;
 				}
 			}
+			// Only subtract scores if dice are not currently moving
+			let shouldSubtractScore = !throwingDice && !awake;
+
 			// Find the volume being clicked within the diceArray to remove it.
 			if (intersectedObject == null) {
-				if (index < diceArray.length && diceArray[index][3]) {
+				if (index < diceArray.length && diceArray[index][3] && shouldSubtractScore) {
 					// If the volume being removed is a numbered volume then get the number on top of the volume and remove it from the score.
 					let score;
 					switch (diceArray[index][2]) {
@@ -931,7 +927,7 @@ define([
 			} else {
 				for (let i = 0; i < diceArray.length; i++) {
 					if (diceArray[i][0] == intersectedObject) {
-						if (diceArray[i][3]) {
+						if (diceArray[i][3] && shouldSubtractScore) {
 							// If the volume being removed is a numbered volume then get the number on top of the volume and remove it from the score.
 							let score;
 							switch (diceArray[i][2]) {
@@ -1473,7 +1469,6 @@ define([
 			if (diceArray.length > 0) {
 				scoresObject.lastRoll = "";
 				scoresObject.presentScore = 0;
-				updateElements();
 				for (let i = 0; i < diceArray.length; i++) {
 					diceArray[i][1].angularVelocity.set(
 						diceArray[i][7],


### PR DESCRIPTION
Fix : #1774 

Issue : 
the activity would:
- subtract the original score values instead of the new values shown on the dice after shaking
- resulting in incorrect scores, sometimes negative values

Fix : 
- Added proper synchronization to ensure dice scores are accurately calculated before removal
- score calculation function called to update the current values
- correct score values are subtracted from the total values

Demo:

https://github.com/user-attachments/assets/46e24b5b-1104-4585-9f3e-c9b2b606ddac

