### PR TITLE
Fix #1803: Activity icons lose colors when navigating in restricted mode (Ring View)

### DIFF
--- a/js/screens/homescreen.js
+++ b/js/screens/homescreen.js
@@ -18,6 +18,7 @@ const HomeScreen = {
 											:ref="'activity'+activity.id"
 											class="home-icon"
 											:svgfile="activity.directory + '/' + activity.icon"
+											:color="activityColors[activity.id]"
 											:x="restrictedModeInfo.positions != undefined ? restrictedModeInfo.positions[index].x : (activityPositions[index] ? activityPositions[index].x : 0)"
 											:y="restrictedModeInfo.positions != undefined ? restrictedModeInfo.positions[index].y : (activityPositions[index] ? activityPositions[index].y : 0)"
 											isNative="true"
@@ -112,6 +113,7 @@ const HomeScreen = {
 			favactivities: [],
 			activities: [],
 			activityPositions: [],
+			activityColors: {},
 			popup: null, // singular popup data
 			username: null,
 			buddycolor: null,
@@ -297,11 +299,7 @@ const HomeScreen = {
 				if (popup.itemList && popup.itemList.length >= 1) {
 					popup.icon.color = iconColor;
 					const iconRef = this.$refs["activity" + popup.id][0];
-					if (iconRef) {
-						iconRef.wait().then(() => {
-							iconRef.colorData = iconColor;
-						})
-					}
+					this.activityColors[activity.id] = iconColor;
 				}
 				popupData[activity.id] = popup;
 			});
@@ -559,17 +557,11 @@ const HomeScreen = {
 
 				this.restrictedModeInfo.start = newStart;
 				this.restrictedModeInfo.activities = activities.slice(this.restrictedModeInfo.start, this.restrictedModeInfo.start + this.restrictedModeInfo.count)
-				this.$nextTick(() => {
-					this.computePopup();
-				});
 				return;
 
 			}
 			this.restrictedModeInfo.start = newStart;
 			this.restrictedModeInfo.activities = activities.slice(this.restrictedModeInfo.start, this.restrictedModeInfo.start + this.restrictedModeInfo.count - 2)
-			this.$nextTick(() => {
-				this.computePopup();
-			});
 		},
 
 		showPreviousRestrictedList() {
@@ -582,16 +574,10 @@ const HomeScreen = {
 				this.restrictedModeInfo.start = newStart;
 				this.restrictedModeInfo.positions = this.activityPositions.slice(this.restrictedModeInfo.count + 1);
 				this.restrictedModeInfo.activities = activities.slice(this.restrictedModeInfo.start, this.restrictedModeInfo.start + this.restrictedModeInfo.count - 1);
-				this.$nextTick(() => {
-					this.computePopup();
-				});
 				return;
 			}
 			this.restrictedModeInfo.start = newStart;
 			this.restrictedModeInfo.activities = activities.slice(this.restrictedModeInfo.start, this.restrictedModeInfo.start + this.restrictedModeInfo.count - 2);
-			this.$nextTick(() => {
-				this.computePopup();
-			});
 		},
 
 		quitApp() {

--- a/js/screens/homescreen.js
+++ b/js/screens/homescreen.js
@@ -559,11 +559,17 @@ const HomeScreen = {
 
 				this.restrictedModeInfo.start = newStart;
 				this.restrictedModeInfo.activities = activities.slice(this.restrictedModeInfo.start, this.restrictedModeInfo.start + this.restrictedModeInfo.count)
+				this.$nextTick(() => {
+					this.computePopup();
+				});
 				return;
 
 			}
 			this.restrictedModeInfo.start = newStart;
 			this.restrictedModeInfo.activities = activities.slice(this.restrictedModeInfo.start, this.restrictedModeInfo.start + this.restrictedModeInfo.count - 2)
+			this.$nextTick(() => {
+				this.computePopup();
+			});
 		},
 
 		showPreviousRestrictedList() {
@@ -576,10 +582,16 @@ const HomeScreen = {
 				this.restrictedModeInfo.start = newStart;
 				this.restrictedModeInfo.positions = this.activityPositions.slice(this.restrictedModeInfo.count + 1);
 				this.restrictedModeInfo.activities = activities.slice(this.restrictedModeInfo.start, this.restrictedModeInfo.start + this.restrictedModeInfo.count - 1);
+				this.$nextTick(() => {
+					this.computePopup();
+				});
 				return;
 			}
 			this.restrictedModeInfo.start = newStart;
 			this.restrictedModeInfo.activities = activities.slice(this.restrictedModeInfo.start, this.restrictedModeInfo.start + this.restrictedModeInfo.count - 2);
+			this.$nextTick(() => {
+				this.computePopup();
+			});
 		},
 
 		quitApp() {


### PR DESCRIPTION
fixes #1803 

## Problem
In ring view on small screens, when clicking the "more activities" icon (three dots) to navigate through the restricted activity list, all activity icons would lose their colors. The colors would only return after navigating back to the home screen and clicking an activity.

This issue occurred specifically in ring view, which is activated on smaller screens when there isn't enough space to display all activities in the full spiral layout.

## Root Cause
 The `showNextRestrictedList()` and `showPreviousRestrictedList()` functions were updating `restrictedModeInfo.activities` to show different sets of activities, but **were not calling `computePopup()`** to apply colors to the newly displayed activity icons.

The `computePopup()` function is responsible for applying icon colors based on journal entries, and without this call, the new activity icons would render with their default colors (when the DOM is re-rendered) instead of the personalized colors from previous usage.

## Solution
Added `computePopup()` calls wrapped in `this.$nextTick()` to both the functions. The `$nextTick()` wrapper ensures that:

1. Vue completes the DOM re-rendering after `restrictedModeInfo.activities` changes
2. Vue refs point to the correct new DOM elements
3. `computePopup()` can successfully access and apply colors to the newly rendered activity
  icons