### PR TITLE
Closes #838: add undo/redo buttons and shortcuts for gears activity

### DIFF
--- a/activities/Gears.activity/css/activity.css
+++ b/activities/Gears.activity/css/activity.css
@@ -35,6 +35,14 @@ body {
   background-image: url(../icons/edit-clear.svg);
 }
 
+#main-toolbar #undo-button {
+  background-image: url(../icons/edit-undo.svg);
+}
+
+#main-toolbar #redo-button {
+  background-image: url(../icons/edit-redo.svg);
+}
+
 #main-toolbar #help-button {
   background-image: url(../icons/help.svg);
 }

--- a/activities/Gears.activity/icons/edit-redo.svg
+++ b/activities/Gears.activity/icons/edit-redo.svg
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="55px"
+	 height="55px" viewBox="0 0 55 55" enable-background="new 0 0 55 55" xml:space="preserve">
+
+<g id="Redo" >
+	<g display="inline">
+		<polyline fill="none" stroke="#FFFFFF" stroke-width="2.9867" stroke-linecap="round" stroke-linejoin="round" points="
+			33.067,27.523 40.879,20.935 33.067,14.344 		"/>
+		<path fill="none" stroke="#FFFFFF" stroke-width="2.9867" stroke-linecap="round" d="M40.879,20.935H23.625
+			c-4.693,0-8.534,3.841-8.534,8.534s3.841,8.533,8.534,8.533h15.548"/>
+	</g>
+</g>
+
+</svg>

--- a/activities/Gears.activity/icons/edit-undo.svg
+++ b/activities/Gears.activity/icons/edit-undo.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 13.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 14948)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" width="55px"
+	 height="55px" viewBox="0 0 55 55" enable-background="new 0 0 55 55" xml:space="preserve">
+
+<g id="Undo" >
+	<g display="inline">
+		<polyline fill="none" stroke="#FFFFFF" stroke-width="2.9867" stroke-linecap="round" stroke-linejoin="round" points="
+			22.903,27.523 15.091,20.935 22.903,14.344 		"/>
+		<path fill="none" stroke="#FFFFFF" stroke-width="2.9867" stroke-linecap="round" d="M15.091,20.935h17.254
+			c4.693,0,8.534,3.841,8.534,8.534s-3.841,8.533-8.534,8.533H16.798"/>
+	</g>
+</g>
+</svg>

--- a/activities/Gears.activity/index.html
+++ b/activities/Gears.activity/index.html
@@ -26,6 +26,8 @@
       <button class="toolbutton" id="momentum-button" title="Momentum"></button>
       <button class="toolbutton play" id="play-button" title="Play"></button>
       <div class="seprator-line"></div>
+      <button class="toolbutton" id="undo-button" title="Undo"></button>
+      <button class="toolbutton" id="redo-button" title="Redo"></button>
       <button class="toolbutton" id="clear-button" title="Clear"></button>
       <button class="toolbutton pull-right" id="stop-button" title="Stop"></button>
       <button class="toolbutton pull-right" id="fullscreen-button" title="Fullscreen"></button>

--- a/activities/Gears.activity/index.html
+++ b/activities/Gears.activity/index.html
@@ -28,6 +28,7 @@
       <div class="seprator-line"></div>
       <button class="toolbutton" id="undo-button" title="Undo"></button>
       <button class="toolbutton" id="redo-button" title="Redo"></button>
+      <div class="seprator-line"></div>
       <button class="toolbutton" id="clear-button" title="Clear"></button>
       <button class="toolbutton pull-right" id="stop-button" title="Stop"></button>
       <button class="toolbutton pull-right" id="fullscreen-button" title="Fullscreen"></button>

--- a/activities/Gears.activity/js/activity.js
+++ b/activities/Gears.activity/js/activity.js
@@ -25,6 +25,9 @@ define(["sugar-web/activity/activity","sugar-web/graphics/radiobuttonsgroup","ge
 
         gearSketch = new window.gearsketch.GearSketch(false);
 
+        // Initialize undo/redo functionality
+        initHistory();
+
         // History Manager
         var MAX_HISTORY = 50;
         var undoStack = [];
@@ -166,6 +169,8 @@ define(["sugar-web/activity/activity","sugar-web/graphics/radiobuttonsgroup","ge
         }
 
         function installInteractionHooks() {
+            if (gearSketch.__interactionWrapped) { return; }
+            gearSketch.__interactionWrapped = true;
             var originalHandlePenDown = gearSketch.handlePenDown.bind(gearSketch);
             gearSketch.handlePenDown = function(x, y) {
                 if (!this.getButtonAt(x, y)) {
@@ -210,7 +215,6 @@ define(["sugar-web/activity/activity","sugar-web/graphics/radiobuttonsgroup","ge
             else {
                 console.log("read failed.");
             }
-            initHistory();
         }
         datastoreObject.loadAsText(onLoaded);
 

--- a/activities/Gears.activity/js/activity.js
+++ b/activities/Gears.activity/js/activity.js
@@ -25,17 +25,192 @@ define(["sugar-web/activity/activity","sugar-web/graphics/radiobuttonsgroup","ge
 
         gearSketch = new window.gearsketch.GearSketch(false);
 
+        // History Manager
+        var MAX_HISTORY = 50;
+        var undoStack = [];
+        var redoStack = [];
+        var transactionActive = false;
+        var snapshotCapturedThisTx = false;
+        var mutationHappenedThisTx = false;
+
+        function serializeBoard() {
+            try {
+                return JSON.stringify(gearSketch.board);
+            } catch (e) {
+                return null;
+            }
+        }
+
+        function deserializeBoard(str) {
+            try {
+                return window.gearsketch.model.Board.fromObject(JSON.parse(str));
+            } catch (e) {
+                return null;
+            }
+        }
+
+        function updateUndoRedoButtons() {
+            var undoBtn = document.getElementById('undo-button');
+            var redoBtn = document.getElementById('redo-button');
+            if (undoBtn) undoBtn.disabled = undoStack.length === 0;
+            if (redoBtn) redoBtn.disabled = redoStack.length === 0;
+        }
+
+        function beginTransaction() {
+            transactionActive = true;
+            snapshotCapturedThisTx = false;
+            mutationHappenedThisTx = false;
+        }
+
+        function endTransaction() {
+            if (transactionActive && snapshotCapturedThisTx && !mutationHappenedThisTx && undoStack.length > 0) {
+                undoStack.pop();
+            }
+            transactionActive = false;
+            snapshotCapturedThisTx = false;
+            mutationHappenedThisTx = false;
+            updateUndoRedoButtons();
+        }
+
+        function ensurePrechangeSnapshot() {
+            if (transactionActive && !snapshotCapturedThisTx) {
+                var snap = serializeBoard();
+                if (snap) {
+                    redoStack = [];
+                    undoStack.push(snap);
+                    if (undoStack.length > MAX_HISTORY) undoStack.shift();
+                    snapshotCapturedThisTx = true;
+                    updateUndoRedoButtons();
+                }
+            }
+        }
+
+        function applyState(serialized) {
+            var newBoard = deserializeBoard(serialized);
+            if (!newBoard) return;
+            gearSketch.board = newBoard;
+            installBoardHooks();
+            gearSketch.selectedGear = null;
+            gearSketch.goalLocationGear = null;
+        }
+
+        function undo() {
+            if (undoStack.length === 0) return;
+            var current = serializeBoard();
+            var prev = undoStack.pop();
+            if (current) redoStack.push(current);
+            applyState(prev);
+            updateUndoRedoButtons();
+        }
+
+        function redo() {
+            if (redoStack.length === 0) return;
+            var current = serializeBoard();
+            var next = redoStack.pop();
+            if (current) undoStack.push(current);
+            applyState(next);
+            updateUndoRedoButtons();
+        }
+
+        function installBoardHooks() {
+            var board = gearSketch.board;
+
+            if (!board.__historyWrapped) {
+                var originalPlaceGear = board.placeGear.bind(board);
+                board.placeGear = function(gear, location) {
+                    ensurePrechangeSnapshot();
+                    var result = originalPlaceGear(gear, location);
+                    if (result) { mutationHappenedThisTx = true; }
+                    return result;
+                };
+
+                var originalAddGear = board.addGear.bind(board);
+                board.addGear = function(gear) {
+                    ensurePrechangeSnapshot();
+                    var result = originalAddGear(gear);
+                    if (result) { mutationHappenedThisTx = true; }
+                    return result;
+                };
+
+                var originalRemoveGear = board.removeGear.bind(board);
+                board.removeGear = function(gear) {
+                    ensurePrechangeSnapshot();
+                    mutationHappenedThisTx = true;
+                    return originalRemoveGear(gear);
+                };
+
+                var originalAddChain = board.addChain.bind(board);
+                board.addChain = function(chain) {
+                    ensurePrechangeSnapshot();
+                    var result = originalAddChain(chain);
+                    if (result) { mutationHappenedThisTx = true; }
+                    return result;
+                };
+
+                var originalRemoveChain = board.removeChain.bind(board);
+                board.removeChain = function(chain) {
+                    ensurePrechangeSnapshot();
+                    mutationHappenedThisTx = true;
+                    return originalRemoveChain(chain);
+                };
+
+                var originalClear = board.clear.bind(board);
+                board.clear = function() {
+                    ensurePrechangeSnapshot();
+                    mutationHappenedThisTx = true;
+                    return originalClear();
+                };
+
+                board.__historyWrapped = true;
+            }
+        }
+
+        function installInteractionHooks() {
+            var originalHandlePenDown = gearSketch.handlePenDown.bind(gearSketch);
+            gearSketch.handlePenDown = function(x, y) {
+                if (!this.getButtonAt(x, y)) {
+                    beginTransaction();
+                    if (this.selectedButton === 'momentumButton') {
+                        ensurePrechangeSnapshot();
+                    }
+                }
+                return originalHandlePenDown(x, y);
+            };
+
+            var originalHandlePenUp = gearSketch.handlePenUp.bind(gearSketch);
+            gearSketch.handlePenUp = function() {
+                var wasMomentumGesture = (this.selectedButton === 'momentumButton') && (this.selectedGear != null);
+                var r = originalHandlePenUp();
+                if (wasMomentumGesture) { mutationHappenedThisTx = true; }
+                endTransaction();
+                return r;
+            };
+        }
+
+        function initHistory() {
+            undoStack = [];
+            redoStack = [];
+            transactionActive = false;
+            snapshotCapturedThisTx = false;
+            mutationHappenedThisTx = false;
+            installBoardHooks();
+            installInteractionHooks();
+            updateUndoRedoButtons();
+        }
+
         // Read from the datastore
         var datastoreObject = activity.getDatastoreObject();
         function onLoaded(error, metadata, jsonData) {
             if (error === null) {
                 gearSketch.board = window.gearsketch.model.Board.
                     fromObject(JSON.parse(jsonData));
+                installBoardHooks();
                 console.log("read done.");
             }
             else {
                 console.log("read failed.");
             }
+            initHistory();
         }
         datastoreObject.loadAsText(onLoaded);
 
@@ -113,7 +288,39 @@ define(["sugar-web/activity/activity","sugar-web/graphics/radiobuttonsgroup","ge
                 return;
             }
             UISwitch('pause', 'play');
+            beginTransaction();
             gearSketch.board.clear();
+            endTransaction();
+        });
+
+        // Undo/Redo buttons
+        var undoButton = document.getElementById('undo-button');
+        if (undoButton) {
+            undoButton.addEventListener('click', function (e) {
+                e.preventDefault();
+                undo();
+            });
+        }
+        var redoButton = document.getElementById('redo-button');
+        if (redoButton) {
+            redoButton.addEventListener('click', function (e) {
+                e.preventDefault();
+                redo();
+            });
+        }
+
+        // Keyboard shortcuts: Cmd/Ctrl+Z (undo), Cmd/Ctrl+Y (redo)
+        window.addEventListener('keydown', function(e) {
+            var mod = e.metaKey || e.ctrlKey;
+            if (!mod) return;
+            var key = e.key ? e.key.toLowerCase() : '';
+            if (key === 'z' && !e.shiftKey) {
+                e.preventDefault();
+                undo();
+            } else if (key === 'y' && !e.shiftKey) {
+                e.preventDefault();
+                redo();
+            }
         });
 
         // Help button.


### PR DESCRIPTION
closes #838 

- added undo/redo buttons to the gears activity toolbar
- history manager to track user edits
- redo stack clears on new edits
- keyboard shortcuts
- works only for the current loaded board and is not persisted to the journal