### PR TITLE
Fix: Open links properly in Firefox for EbookReader (#1429)

### DIFF
--- a/activities/EbookReader.activity/js/activity.js
+++ b/activities/EbookReader.activity/js/activity.js
@@ -282,3 +282,17 @@ var app = new Vue({
 		}
 	}
 });
+
+document.addEventListener("click", function (event) {
+	const link = event.target.closest("a");
+	if (link && link.href) {
+		event.preventDefault();
+		const url = link.href;
+		if (typeof window.sugarizerOS !== "undefined" && window.sugarizerOS.openBrowser) {
+			window.sugarizerOS.openBrowser(url);
+		} else {
+			window.open(url, "_blank", "noopener,noreferrer");
+		}
+	}
+});
+


### PR DESCRIPTION
This PR fixes the issue where links inside the EbookReader were not opening correctly in Firefox.

- Added a global click handler that intercepts <a> tags and opens them:
- Uses Sugarizer OS internal browser if available.
 - Falls back to a new browser tab in standard browsers.

Note: I could not fully test this locally because I don’t have access to the Sugarizer environment (could not bypass login or load the Journal context). Maintainers will need to verify it in the full environment.

Closes #1429
