### PR TITLE
This PR introduces a dedicated Quit button to the Sugarizer desktop toolbar, allowing users to exit the application directly from the home screen.Add quit button to desktop toolbar

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -95,6 +95,13 @@ body {
 	right: 90px;
 }
 
+.quit-button {
+	background-image: url(../icons/system-shutdown.svg);
+	position: absolute !important;
+	top: 0px;
+	right: 210px;   /* try this first, then tweak */
+}
+
 .help-button {
 	background-image: url(../icons/help.svg);
 	position: absolute !important;

--- a/js/homeview.js
+++ b/js/homeview.js
@@ -764,8 +764,10 @@ enyo.kind({
 		{name: "assignmentCount", tag:"p", classes: " assignment-count ", title:"count",},
 		{name: "radialbutton", kind: "Button", classes: "toolbutton view-radial-button active", title:"Home", ontap: "showRadialView"},
 		{name: "neighborbutton", kind: "Button", classes: "toolbutton view-neighbor-button", title:"Home", ontap: "showNeighborView"},
-		{name: "listbutton", kind: "Button", classes: "toolbutton view-list-button", title:"List", ontap: "showListView"}
-	],
+		{name: "listbutton", kind: "Button", classes: "toolbutton view-list-button", title:"List", ontap: "showListView"},
+		{name: "quitbutton", kind: "Button", classes: "toolbutton quit-button", title: "Quit", ontap: "quitApp"}
+	
+	],	
 
 	// Constructor
 	create: function() {
@@ -785,6 +787,8 @@ enyo.kind({
 		this.$.neighborbutton.setNodeProperty("title", l10n.get("NeighborhoodView"));
 		this.$.helpbutton.setNodeProperty("title", l10n.get("Tutorial"));
 		this.$.offlinebutton.setNodeProperty("title", l10n.get("NotConnected"));
+		this.$.quitbutton.setNodeProperty("title", l10n.get("Quit"));
+
 		if (app.localize) {
 			app.localize();
 		}
@@ -891,6 +895,18 @@ enyo.kind({
 		}
 		var otherview = app.$.otherview.createComponent({kind: "Sugar.DialogServer", standalone: true}, {owner:this});
 		otherview.show();
+	},
+
+	quitApp: function() {
+		// Reuse the existing desktop quit logic if available
+		if (app && app.doQuit) {
+			app.doQuit();           // calls stats.trace + util.quitApp()
+		} else if (typeof util !== "undefined" && util.quitApp) {
+			util.quitApp();         // fallback
+		} else {
+			// Final fallback: try to close browser window
+			window.close();
+		}
 	},
 
 	startTutorial: function() {


### PR DESCRIPTION
 Changes:
- Added a new toolbar component `quitbutton` to `Sugar.DesktopToolbar` in `js/homeview.js`.
- Implemented `quitApp()` handler to reuse existing desktop quit logic for safe app exit.
- Styled the **Quit button** in `css/styles.css` using the same layout pattern as existing toolbar view buttons.
- Positioned the button next to the system icons without overlapping the search bar or other UI elements.
- Preserved UI alignment and visual consistency with the current toolbar design.


Testing:
- Verified the Quit button is visible and properly aligned in the toolbar.
- Confirmed no overlap with the search field or other toolbar buttons.
- Tested click behavior to ensure the application exits correctly.
- Tested layout stability after refresh and hard reload.


 Screenshots:
*(Screenshot attached showing the Quit button placement in the desktop toolbar)*


Notes:
This implementation follows the existing toolbar layout strategy (absolute positioning used by view buttons) to maintain consistency and avoid layout regressions or CSS overlays.
<img width="1920" height="1200" alt="Screenshot 2025-12-02 053229" src="https://github.com/user-attachments/assets/a94b76df-53af-4321-945d-c3bea5d604cc" />
