### PR TITLE
Remove requirejs import from main.js dependancies

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,7 +4,6 @@ var electron = require('electron'),
 	fs = require('fs'),
 	temp = require('tmp'),
 	path = require('path'),
-	requirejs = require('requirejs'),
 	activities = require('./activities.json'),
 	l10n = require('./lib/l10n');
 


### PR DESCRIPTION
The import was not referenced anywhere in the activity. Removing it reduces unnecessary dependencies. The activity was tested locally using the standard development workflow. All functionality works as expected without the requirejs import.