### PR TITLE
Fix #1830: Improve visual contrast for Home view search results

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1096,6 +1096,19 @@ a {
 	opacity: 0.5;
 }
 
+/* Search highlighting classes */
+.activity-search-match {
+	opacity: 1 !important;
+	filter: saturate(1.3) brightness(1.1);
+	transition: filter 0.2s ease, opacity 0.2s ease;
+}
+
+.activity-search-no-match {
+	opacity: 0.25 !important;
+	filter: saturate(0.5) brightness(0.7);
+	transition: filter 0.2s ease, opacity 0.2s ease;
+}
+
 .sync-gear {
 	animation-name: sync-frame;
 	animation-duration: 2s;

--- a/js/components/icon.js
+++ b/js/components/icon.js
@@ -29,6 +29,8 @@ const Icon ={
 	name: 'Icon',
 	template: `<div :class="[
 		this.disabledData ? 'web-activity-disable' : '',
+		this.searchMatchData === true ? 'activity-search-match' : '',
+		this.searchMatchData === false ? 'activity-search-no-match' : '',
 		disableHoverEffect ? '' : 'icon',
 		].join(' ')" ref="icon" v-html="gensvg" :id="this.idData"></div>`,
 	props: {
@@ -54,6 +56,7 @@ const Icon ={
 			xData: this.x ? this.x: 0,
 			yData: this.y ? this.y: 0,
 			disabledData: this.disabled ? this.disabled: false,
+			searchMatchData: null,
 			_originalColor: { fill: null, stroke: null},
 			_element: null,
 			fallback: false

--- a/js/screens/homescreen.js
+++ b/js/screens/homescreen.js
@@ -209,12 +209,21 @@ const HomeScreen = {
 		},
 
 		filterSearch(filter) {
+			const hasSearch = filter && filter.trim().length > 0;
 			for (let i = 0; i < this.activities.length; i++) {
 				let ref = this.$refs["activity" + this.activities[i].id];
 				if (!ref || ref.length == 0) {
 					continue;
 				}
-				ref[0].disabledData = !this.activities[i].name.toUpperCase().includes(filter.toUpperCase());
+				const isMatch = this.activities[i].name.toUpperCase().includes(filter.toUpperCase());
+				ref[0].disabledData = !isMatch;
+				
+				// Apply search highlighting classes only when search is active
+				if (hasSearch) {
+					ref[0].searchMatchData = isMatch;
+				} else {
+					ref[0].searchMatchData = null;
+				}
 			}
 		},
 


### PR DESCRIPTION
Fixes #1830

### What this PR does
- Improves visual focus of matched activities during Home view search
- Dims non-matching activities while search is active
- Restores original appearance when search is cleared

### How to test
1. Run `npm start`
2. Use the Home view search bar
3. Verify matched activities stand out
4. Clear search and confirm UI resets

### Screenshots
Before:
![526296834-756b55b4-48a3-4bbe-aff4-0c1a638c2034](https://github.com/user-attachments/assets/4accc3af-19e3-4194-a77a-c65ed894539d)

After:
<img width="1440" height="900" alt="Screenshot from 2025-12-18 19-38-10" src="https://github.com/user-attachments/assets/d2cb2231-9aef-49b9-97cb-f29178600e89" />

