### PR TITLE
Replace deprecated Buffer constructor with Buffer.from()

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,7 +31,7 @@ function saveFile(file, arg, sender) {
 		buf = arg.text;
 	} else {
 		var data = arg.binary.replace(/^data:.+;base64,/, "");
-		buf = new Buffer(data, 'base64');
+		buf = Buffer.from(data, 'base64');  // ✅ modern API
 	}
 	fs.writeFile(file, buf, function(err) {
 		sender.send('save-file-reply', {err: err, filename: file});


### PR DESCRIPTION
This PR replaces usage of the deprecated `new Buffer()` constructor
with `Buffer.from()` in the Electron main process.

### Why
- `new Buffer()` is deprecated in Node.js
- Avoids deprecation warnings in modern Electron/Node versions
- Aligns with current Node.js best practices

### Impact
- No functional or behavioral changes
- Improves code safety and maintainability

Fixes #1855