### PR TITLE
Fix incorrect assignment operator in PhysicsJS activity

### DIFF
--- a/activities/PhysicsJS.activity/js/activity.js
+++ b/activities/PhysicsJS.activity/js/activity.js
@@ -423,7 +423,7 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env"], functi
 				} else if (savedObject.type == "rectangle") {
 					newOptions.width = savedObject.width;
 					newOptions.height = savedObject.height;
-				} else if (savedObject.type = "convex-polygon") {
+				} else if (savedObject.type == "convex-polygon") {
 					newOptions.vertices = savedObject.vertices;
 				}
 				return Physics.body(savedObject.type, newOptions);
@@ -540,7 +540,7 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env"], functi
 								object.radius = Math.max(40, distance);
 							} else if (object.type == "rectangle") {
 								object.width = object.height = Math.max(50, distance);
-							} else if (object.type = "convex-polygon") {
+							} else if (object.type == "convex-polygon") {
 								object.vertices = Physics.geometry.regularPolygonVertices( object.vertices.length, Math.max(30, distance));
 							}
 							world.removeBody(createdBody);


### PR DESCRIPTION
This PR fixes an issue in the PhysicsJS activity where an assignment operator
(=) was mistakenly used instead of a comparison operator in conditional
statements.

While reviewing the code, the same bug pattern was found in another
conditional and has been fixed as well.

Fixes #1870
