### PR TITLE
Fix undeclared variable in confirmOperation() loop

### DIFF
--- a/js/screens/journal.js
+++ b/js/screens/journal.js
@@ -696,7 +696,7 @@ const Journal = {
 		async confirmOperation() {
 			this.showWarning = false;
 			this.checkboxSelected = 0;
-			for (entry of this.processedJournal) {
+			for (const entry of this.processedJournal) {
 				if (
 					entry.isChecked &&
 					this.currentOperation &&


### PR DESCRIPTION
Add const declaration to for-of loop to prevent global scope pollution. The missing declaration caused 'entry' to be created as a global variable (window.entry), violating JavaScript standards and preventing garbage collection.

Fixes #1867