### PR TITLE
 resize images in Fototoon

### DIFF
--- a/activities/Fototoon.activity/js/activity.js
+++ b/activities/Fototoon.activity/js/activity.js
@@ -204,7 +204,8 @@ define(["sugar-web/activity/activity","sugar-web/datastore","sugar-web/env","tex
             };
             toonModel.showWait();
             if (editMode) {
-                toonModel.initPreviews();
+                // Wait for all previews to be generated before showing sort view
+                toonModel.initPreviews(function(){;
                 // resize the canvas
                 sortCanvas.width = window.innerWidth - sugarCellSize * 2;
                 var boxWidth = sortCanvas.width / toonModel.getData()['boxs'].length;
@@ -212,14 +213,17 @@ define(["sugar-web/activity/activity","sugar-web/datastore","sugar-web/env","tex
                 sortCanvas.style.left = ((window.innerWidth - sortCanvas.width) / 2) + "px";
                 sortCanvas.style.top = ((window.innerHeight - sortCanvas.height) / 2) + "px";
                 toonModel.initSort(sortCanvas);
+                toonModel.hideWait();
+                    // switch editMode
+                    editMode = !editMode;
+                });
             } else {
                 toonModel.finishSort();
                 toonModel.init();
+                toonModel.hideWait();
+                // switch editMode
+                editMode = ! editMode;
             };
-            toonModel.hideWait();
-            // switch editMode
-            editMode = ! editMode;
-
         });
 
         var cleanAllButton = document.getElementById("clean-all-button");


### PR DESCRIPTION
issue #1551 
Previously, images were applied as a static background to the canvas, which made them impossible to change. I refactored this logic so images are now rendered as interactive objects, allowing the user to resize them freely.

preview:

https://github.com/user-attachments/assets/3c806822-2118-49b7-8d0d-16043d63cfbf



