### PR TITLE
Fix: Global variable leak in i18next module due to variable typo

### DIFF
--- a/js/modules/i18next.js
+++ b/js/modules/i18next.js
@@ -113,19 +113,19 @@ define(["lib/i18next.min.js", "lib/i18next-vue.js"], function (
 		if (bytes === undefined) return "-";
 		var formatted = "";
 		if (bytes > 1048576) {
-			formated =
+			formatted =
 				(bytes / 1024 / 1024).toFixed() +
 				" " +
 				i18next.t("ShortForMegabytes");
 		} else if (bytes > 1024) {
-			formated =
+			formatted =
 				(bytes / 1024).toFixed() + " " + i18next.t("ShortForKilobytes");
 		} else if (bytes == 0) {
-			formated = "-";
+			formatted = "-";
 		} else {
-			formated = bytes + " " + i18next.t("ShortForBytes");
+			formatted = bytes + " " + i18next.t("ShortForBytes");
 		}
-		return formated;
+		return formatted;
 	};
 
 	return {


### PR DESCRIPTION
## Description
This PR fixes a global variable leak in the [getFormattedSize]

### The Issue
A local variable was declared as `formatted`, but the function used an undeclared variable `formated` (missing a 't') for assignments. This caused the size string to be attached to the global `window` object every time a file size was formatted.

### Changes
- Corrected all instances of `formated` to the properly declared `formatted` variable.
- Verified that the variable remains scoped to the function and no longer pollutes the global namespace.

Fixes:#1921