### PR TITLE
Fix camera issue in QRCode activity

### DIFF
--- a/activities/QRCode.activity/js/activity.js
+++ b/activities/QRCode.activity/js/activity.js
@@ -229,6 +229,9 @@ define(["sugar-web/activity/activity","sugar-web/datastore", "sugar-web/env", "l
 			// Handle HTML5 capture
 			var outdiv = document.getElementById("outdiv");
 			var videostream = document.getElementById("video-stream");
+			if (videostream) {
+				videostream.style.visibility = "visible";
+			}
 			if (!photoButton.classList.contains('active')) {
 				document.getElementById("qr-code").style.visibility = "hidden";
 				document.getElementById("loading-spinner").style.visibility = "visible";
@@ -243,8 +246,10 @@ define(["sugar-web/activity/activity","sugar-web/datastore", "sugar-web/env", "l
 					videostream.style.visibility = "visible";
 				}
 			} else {
-				outdiv.style.visibility = "hidden";
-				videostream.style.visibility = "hidden";
+				if (typeof stopWebcam === "function") {
+					stopWebcam();
+				}
+				photoInitialized = false;
 				document.getElementById("loading-spinner").style.visibility = "hidden";
 				document.getElementById("qr-code").style.visibility = "visible";
 				userText.value = oldUserText;

--- a/activities/QRCode.activity/js/webqr.js
+++ b/activities/QRCode.activity/js/webqr.js
@@ -12,6 +12,7 @@ var v=null;
 var qrSize = 0;
 var margin = 0;
 var scannedCallback = null;
+var currentStream = null;
 
 
 var vidhtml = '<video id="video-stream" autoplay></video>';
@@ -83,8 +84,8 @@ function isCanvasSupported(){
   return !!(elem.getContext && elem.getContext('2d'));
 }
 function success(stream)
-{
-
+{    
+    currentStream = stream;
     v.srcObject = stream;
     v.play();
 
@@ -183,4 +184,25 @@ function setwebcam2(options)
 
     stype=1;
     setTimeout(captureToCanvas, 500);
+}
+function stopWebcam() {
+    if (currentStream) {
+        currentStream.getTracks().forEach(function(track) {
+            track.stop();
+        });
+        currentStream = null;
+    }
+
+    if (v) {
+        v.pause();
+        v.srcObject = null;
+    }
+
+    gUM = false;
+    stype = 0;
+
+    var outdiv = document.getElementById("outdiv");
+    if (outdiv) {
+        outdiv.innerHTML = "";
+    }
 }


### PR DESCRIPTION
**Summary**

Fixes an issue in QRCode.activity where toggling the Photo/Camera button off restored the UI but left the device camera running in Electron.

Fixes #1911 

**Changes**

1. Track the active MediaStream created by getUserMedia()
2. Explicitly stop all media tracks when Photo mode is toggled off
3. Reset the camera state so toggling Photo mode on again restarts the camera correctly

**Result**

1. The camera turns off immediately when toggled off
2. Camera restarts correctly when toggled back on

**Testing**

Verified on desktop (Electron) by toggling Photo mode on/off multiple times
