### PR TITLE
Fix Paint canvas not resizing when window size changes

### DIFF
--- a/activities/Paint.activity/js/activity.js
+++ b/activities/Paint.activity/js/activity.js
@@ -125,7 +125,7 @@ define(["sugar-web/activity/activity", "tutorial", "l10n", "sugar-web/env", "act
       var canvas = PaintApp.elements.canvas;
       var ctx = canvas.getContext("2d");
 
-      // 1. Save current content before any changes
+      // 1. Save current content synchronously at the START of resize
       if (!resizeBaseCanvas) {
         resizeBaseCanvas = document.createElement('canvas');
         resizeBaseCanvas.width = canvas.width;
@@ -137,41 +137,36 @@ define(["sugar-web/activity/activity", "tutorial", "l10n", "sugar-web/env", "act
       var newWidth = window.innerWidth;
       var newHeight = window.innerHeight - 55;
 
-      // 3. Sync Paper.js AND Canvas Buffer
-      // This is crucial for Windows 11 High DPI display compatibility
+      // 3. Update Paper.js view size (resizes the canvas internally)
       if (typeof paper !== 'undefined' && paper.view) {
         paper.view.viewSize = new paper.Size(newWidth, newHeight);
+        // Important: Stop Paper.js from clearing the canvas manually
         paper.view.autoUpdate = false;
       }
 
-      // Explicitly set styles to ensure no "dead area"
+      // 4. Update CSS size
       canvas.style.width = newWidth + "px";
       canvas.style.height = newHeight + "px";
 
-      // 4. Reset Transform to identity
+      // 5. Restore content synchronously and scale to fit the new size
+      // Reset transform to identity for whole-buffer drawImage
       ctx.setTransform(1, 0, 0, 1, 0, 0);
 
-      // 5. High-Quality Scaling Setup
+      // High-quality scaling settings
       ctx.imageSmoothingEnabled = true;
       ctx.imageSmoothingQuality = 'high';
-      ctx.mozImageSmoothingEnabled = true;
-      ctx.webkitImageSmoothingEnabled = true;
-      ctx.msImageSmoothingEnabled = true;
 
-      // 6. Clear and Restore
+      // Fill with white background (standard for Paint)
       ctx.fillStyle = "#ffffff";
       ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-      // 7. Restore content from the BASE canvas and scale to fit the new size
+      // Draw the original content scaled to fit the new buffer
       ctx.drawImage(resizeBaseCanvas, 0, 0, canvas.width, canvas.height);
 
-      // 8. Refresh Paper.js View (Critical for stability in some browsers)
-      if (typeof paper !== 'undefined' && paper.view) {
-        paper.view.draw();
+      // 6. Reset the base canvas after a period of inactivity (resize finished)
+      if (resizeTimeout) {
+        clearTimeout(resizeTimeout);
       }
-
-      // Cleanup timeout
-      if (resizeTimeout) clearTimeout(resizeTimeout);
       resizeTimeout = setTimeout(function () {
         resizeBaseCanvas = null;
       }, 500);

--- a/activities/Paint.activity/js/activity.js
+++ b/activities/Paint.activity/js/activity.js
@@ -121,12 +121,17 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activit
       }
 
       var canvas = PaintApp.elements.canvas;
+      var ctx = canvas.getContext("2d");
+
+      var imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
 
       canvas.width = window.innerWidth * window.devicePixelRatio;
       canvas.height = window.innerHeight * window.devicePixelRatio;
 
       canvas.style.width = window.innerWidth + "px";
       canvas.style.height = window.innerHeight + "px";
+
+      ctx.putImageData(imageData, 0, 0);
       });
     });
 });

--- a/activities/Paint.activity/js/activity.js
+++ b/activities/Paint.activity/js/activity.js
@@ -115,20 +115,18 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activit
     }
 
     // Fix: Resize canvas when window size changes
-window.addEventListener("resize", function () {
-    if (!PaintApp || !PaintApp.elements || !PaintApp.elements.canvas) {
+    window.addEventListener("resize", function () {
+      if (!PaintApp || !PaintApp.elements || !PaintApp.elements.canvas) {
         return;
-    }
+      }
 
-    var canvas = PaintApp.elements.canvas;
+      var canvas = PaintApp.elements.canvas;
 
-    canvas.width = window.innerWidth * window.devicePixelRatio;
-    canvas.height = window.innerHeight * window.devicePixelRatio;
+      canvas.width = window.innerWidth * window.devicePixelRatio;
+      canvas.height = window.innerHeight * window.devicePixelRatio;
 
-    canvas.style.width = window.innerWidth + "px";
-    canvas.style.height = window.innerHeight + "px";
-});
-
-  });
-
+      canvas.style.width = window.innerWidth + "px";
+      canvas.style.height = window.innerHeight + "px";
+      });
+    });
 });

--- a/activities/Paint.activity/js/activity.js
+++ b/activities/Paint.activity/js/activity.js
@@ -114,6 +114,21 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activit
       PaintApp.collaboration.shareActivity();
     }
 
+    // Fix: Resize canvas when window size changes
+window.addEventListener("resize", function () {
+    if (!PaintApp || !PaintApp.elements || !PaintApp.elements.canvas) {
+        return;
+    }
+
+    var canvas = PaintApp.elements.canvas;
+
+    canvas.width = window.innerWidth * window.devicePixelRatio;
+    canvas.height = window.innerHeight * window.devicePixelRatio;
+
+    canvas.style.width = window.innerWidth + "px";
+    canvas.style.height = window.innerHeight + "px";
+});
+
   });
 
 });

--- a/activities/Paint.activity/js/activity.js
+++ b/activities/Paint.activity/js/activity.js
@@ -125,7 +125,7 @@ define(["sugar-web/activity/activity", "tutorial", "l10n", "sugar-web/env", "act
       var canvas = PaintApp.elements.canvas;
       var ctx = canvas.getContext("2d");
 
-      // 1. Save current content synchronously in a temporary off-screen canvas at the START of resize
+      // 1. Save current content before any changes
       if (!resizeBaseCanvas) {
         resizeBaseCanvas = document.createElement('canvas');
         resizeBaseCanvas.width = canvas.width;
@@ -137,38 +137,41 @@ define(["sugar-web/activity/activity", "tutorial", "l10n", "sugar-web/env", "act
       var newWidth = window.innerWidth;
       var newHeight = window.innerHeight - 55;
 
-      // 3. Update Paper.js view size (this automatically resizes the canvas buffer)
+      // 3. Sync Paper.js AND Canvas Buffer
+      // This is crucial for Windows 11 High DPI display compatibility
       if (typeof paper !== 'undefined' && paper.view) {
         paper.view.viewSize = new paper.Size(newWidth, newHeight);
-        // Prevent Paper.js from clearing the canvas since we use manual drawing
         paper.view.autoUpdate = false;
       }
 
-      // 4. Update CSS size
+      // Explicitly set styles to ensure no "dead area"
       canvas.style.width = newWidth + "px";
       canvas.style.height = newHeight + "px";
 
-      // 6. Reset transform and enable high-quality smoothing
-      // This prevents the "zoom" effect and ensures any future scaling is smooth
+      // 4. Reset Transform to identity
       ctx.setTransform(1, 0, 0, 1, 0, 0);
+
+      // 5. High-Quality Scaling Setup
       ctx.imageSmoothingEnabled = true;
       ctx.imageSmoothingQuality = 'high';
       ctx.mozImageSmoothingEnabled = true;
       ctx.webkitImageSmoothingEnabled = true;
       ctx.msImageSmoothingEnabled = true;
 
-      // 7. Fill with white background
+      // 6. Clear and Restore
       ctx.fillStyle = "#ffffff";
       ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-      // 8. Restore content from the BASE canvas and scale to fit the new size
-      // This ensures the drawing stretches to fill the window while staying sharp
+      // 7. Restore content from the BASE canvas and scale to fit the new size
       ctx.drawImage(resizeBaseCanvas, 0, 0, canvas.width, canvas.height);
 
-      // 9. Reset the base canvas after a period of inactivity (resize finished)
-      if (resizeTimeout) {
-        clearTimeout(resizeTimeout);
+      // 8. Refresh Paper.js View (Critical for stability in some browsers)
+      if (typeof paper !== 'undefined' && paper.view) {
+        paper.view.draw();
       }
+
+      // Cleanup timeout
+      if (resizeTimeout) clearTimeout(resizeTimeout);
       resizeTimeout = setTimeout(function () {
         resizeBaseCanvas = null;
       }, 500);

--- a/activities/Paint.activity/js/activity.js
+++ b/activities/Paint.activity/js/activity.js
@@ -114,9 +114,71 @@ define(["sugar-web/activity/activity", "tutorial", "l10n", "sugar-web/env", "act
       PaintApp.collaboration.shareActivity();
     }
 
-    // Fix: Resize canvas when window size changes
-    var resizeBaseCanvas = null;
-    var resizeTimeout = null;
+    // Fix: Persistent Resize Buffer to prevent erasing hidden content
+    var resizeBufferCanvas = document.createElement('canvas');
+    var resizeBufferContext = resizeBufferCanvas.getContext('2d');
+
+    function syncResizeBuffer() {
+      if (!PaintApp || !PaintApp.elements || !PaintApp.elements.canvas) return;
+      var canvas = PaintApp.elements.canvas;
+
+      // Grow buffer if needed
+      var needsResize = false;
+      if (canvas.width > resizeBufferCanvas.width) {
+        resizeBufferCanvas.width = canvas.width;
+        needsResize = true;
+      }
+      if (canvas.height > resizeBufferCanvas.height) {
+        resizeBufferCanvas.height = canvas.height;
+        needsResize = true;
+      }
+
+      // If we grew the buffer, we should fill the new area with white first
+      if (needsResize) {
+        var tmpCanvas = document.createElement('canvas');
+        tmpCanvas.width = resizeBufferCanvas.width;
+        tmpCanvas.height = resizeBufferCanvas.height;
+        var tmpCtx = tmpCanvas.getContext('2d');
+        tmpCtx.fillStyle = "#ffffff";
+        tmpCtx.fillRect(0, 0, tmpCanvas.width, tmpCanvas.height);
+        tmpCtx.drawImage(resizeBufferCanvas, 0, 0);
+
+        resizeBufferCanvas.width = tmpCanvas.width;
+        resizeBufferCanvas.height = tmpCanvas.height;
+        resizeBufferContext.drawImage(tmpCanvas, 0, 0);
+      }
+
+      // Sync active canvas content to buffer at (0,0)
+      resizeBufferContext.drawImage(canvas, 0, 0);
+    }
+
+    // Wrap PaintApp functions to sync buffer on every state change
+    var oldSaveCanvas = PaintApp.saveCanvas;
+    PaintApp.saveCanvas = function () {
+      oldSaveCanvas.apply(this, arguments);
+      syncResizeBuffer();
+    };
+
+    var oldDisplayButtons = PaintApp.displayUndoRedoButtons;
+    PaintApp.displayUndoRedoButtons = function () {
+      oldDisplayButtons.apply(this, arguments);
+      syncResizeBuffer();
+    };
+
+    var oldClearCanvas = PaintApp.clearCanvas;
+    PaintApp.clearCanvas = function () {
+      oldClearCanvas.apply(this, arguments);
+      // Reset buffer on clear
+      resizeBufferCanvas.width = PaintApp.elements.canvas.width;
+      resizeBufferCanvas.height = PaintApp.elements.canvas.height;
+      resizeBufferContext.fillStyle = "#ffffff";
+      resizeBufferContext.fillRect(0, 0, resizeBufferCanvas.width, resizeBufferCanvas.height);
+    };
+
+    // Initial sync
+    setTimeout(syncResizeBuffer, 500);
+
+    // Update resize listener to use the persistent buffer
     window.addEventListener("resize", function () {
       if (!PaintApp || !PaintApp.elements || !PaintApp.elements.canvas) {
         return;
@@ -125,51 +187,27 @@ define(["sugar-web/activity/activity", "tutorial", "l10n", "sugar-web/env", "act
       var canvas = PaintApp.elements.canvas;
       var ctx = canvas.getContext("2d");
 
-      // 1. Save current content synchronously at the START of resize
-      if (!resizeBaseCanvas) {
-        resizeBaseCanvas = document.createElement('canvas');
-        resizeBaseCanvas.width = canvas.width;
-        resizeBaseCanvas.height = canvas.height;
-        resizeBaseCanvas.getContext('2d').drawImage(canvas, 0, 0);
-      }
-
-      // 2. Compute new size
+      // 1. Compute new size
       var newWidth = window.innerWidth;
       var newHeight = window.innerHeight - 55;
 
-      // 3. Update Paper.js view size (resizes the canvas internally)
+      // 2. Update Paper.js view size (resizes the canvas internally)
       if (typeof paper !== 'undefined' && paper.view) {
         paper.view.viewSize = new paper.Size(newWidth, newHeight);
-        // Important: Stop Paper.js from clearing the canvas manually
         paper.view.autoUpdate = false;
       }
 
-      // 4. Update CSS size
+      // 3. Update CSS size
       canvas.style.width = newWidth + "px";
       canvas.style.height = newHeight + "px";
 
-      // 5. Restore content synchronously and scale to fit the new size
-      // Reset transform to identity for whole-buffer drawImage
+      // 4. Restore content synchronously from persistent buffer
       ctx.setTransform(1, 0, 0, 1, 0, 0);
-
-      // High-quality scaling settings
-      ctx.imageSmoothingEnabled = true;
-      ctx.imageSmoothingQuality = 'high';
-
-      // Fill with white background (standard for Paint)
       ctx.fillStyle = "#ffffff";
       ctx.fillRect(0, 0, canvas.width, canvas.height);
 
-      // Draw the original content scaled to fit the new buffer
-      ctx.drawImage(resizeBaseCanvas, 0, 0, canvas.width, canvas.height);
-
-      // 6. Reset the base canvas after a period of inactivity (resize finished)
-      if (resizeTimeout) {
-        clearTimeout(resizeTimeout);
-      }
-      resizeTimeout = setTimeout(function () {
-        resizeBaseCanvas = null;
-      }, 500);
+      // Draw the persistent buffer content at (0,0) without scaling
+      ctx.drawImage(resizeBufferCanvas, 0, 0);
     });
   });
 });

--- a/activities/Paint.activity/js/activity.js
+++ b/activities/Paint.activity/js/activity.js
@@ -1,5 +1,5 @@
 /* Start of the app, we require everything that is needed */
-define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activity/paint-activity","activity/paint-app","sugar-web/graphics/presencepalette","activity/palettes/color-palette","activity/palettes/stamp-palette","activity/palettes/text-palette","activity/palettes/drawings-palette","activity/palettes/filters-palette","activity/buttons/size-button","activity/buttons/clear-button","activity/buttons/undo-button","activity/buttons/redo-button","activity/modes/modes-pen","activity/modes/modes-eraser","activity/modes/modes-bucket","activity/modes/modes-text","activity/modes/modes-stamp","activity/modes/modes-copy","activity/modes/modes-paste","activity/collaboration","activity/buttons/insertimage-button"], function (activity,tutorial,l10n,env,p1,p2,p3,p4,p5,p6,p7,p8,p9,p10,p11,p12,p13,p14,p15,p16,p17,p18,p19,p20,p21) {
+define(["sugar-web/activity/activity", "tutorial", "l10n", "sugar-web/env", "activity/paint-activity", "activity/paint-app", "sugar-web/graphics/presencepalette", "activity/palettes/color-palette", "activity/palettes/stamp-palette", "activity/palettes/text-palette", "activity/palettes/drawings-palette", "activity/palettes/filters-palette", "activity/buttons/size-button", "activity/buttons/clear-button", "activity/buttons/undo-button", "activity/buttons/redo-button", "activity/modes/modes-pen", "activity/modes/modes-eraser", "activity/modes/modes-bucket", "activity/modes/modes-text", "activity/modes/modes-stamp", "activity/modes/modes-copy", "activity/modes/modes-paste", "activity/collaboration", "activity/buttons/insertimage-button"], function (activity, tutorial, l10n, env, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21) {
   window.PaintApp = p2;
 
   PaintApp.libs.activity = activity;
@@ -30,7 +30,7 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activit
 
   PaintApp.collaboration = p20;
 
-  requirejs(['domReady!', 'sugar-web/datastore', 'paper-core', 'mustache', 'lzstring', 'humane'], function(doc, datastore, _paper, mustache, lzstring, humane) {
+  requirejs(['domReady!', 'sugar-web/datastore', 'paper-core', 'mustache', 'lzstring', 'humane'], function (doc, datastore, _paper, mustache, lzstring, humane) {
 
     /* Fetching and storing libraries */
     PaintApp.libs.mustache = mustache;
@@ -43,13 +43,13 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activit
     /* Fetch and store UI elements */
     initGui();
     var currentenv;
-    env.getEnvironment(function(err, environment) {
+    env.getEnvironment(function (err, environment) {
       currentenv = environment;
       // Set current language to Sugarizer
       var defaultLanguage = (typeof chrome != 'undefined' && chrome.app && chrome.app.runtime) ? chrome.i18n.getUILanguage() : navigator.language;
       var language = environment.user ? environment.user.language : defaultLanguage;
       l10n.init(language);
-      
+
     });
 
     // Export as PNG image
@@ -70,7 +70,7 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activit
       }, inputData);
     });
 
-    document.getElementById("stop-button").addEventListener('click', function(event) {
+    document.getElementById("stop-button").addEventListener('click', function (event) {
       var data = {
         width: PaintApp.elements.canvas.width / window.devicePixelRatio,
         height: PaintApp.elements.canvas.height / window.devicePixelRatio,
@@ -80,23 +80,23 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activit
       var jsonData = JSON.stringify(data);
 
       activity.getDatastoreObject().setDataAsText(jsonData);
-      activity.getDatastoreObject().save(function(error) {});
+      activity.getDatastoreObject().save(function (error) { });
     });
 
-    document.getElementById("help-button").addEventListener('click', function(e) {
+    document.getElementById("help-button").addEventListener('click', function (e) {
       tutorial.start();
     });
 
     //Fetch of the history if not starting shared
     if (!window.top.sugar || !window.top.sugar.environment || !window.top.sugar.environment.sharedId) {
-      activity.getDatastoreObject().loadAsText(function(error, metadata, jsonData) {
+      activity.getDatastoreObject().loadAsText(function (error, metadata, jsonData) {
         if (jsonData == null) {
           return;
         }
         var data = JSON.parse(jsonData);
         PaintApp.clearCanvas();
         img = new Image();
-        img.onload = function() {
+        img.onload = function () {
           PaintApp.elements.canvas.getContext('2d').drawImage(img, 0, 0, data.width, data.height);
           PaintApp.saveCanvas();
         };
@@ -115,6 +115,8 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activit
     }
 
     // Fix: Resize canvas when window size changes
+    var resizeBaseCanvas = null;
+    var resizeTimeout = null;
     window.addEventListener("resize", function () {
       if (!PaintApp || !PaintApp.elements || !PaintApp.elements.canvas) {
         return;
@@ -123,15 +125,53 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activit
       var canvas = PaintApp.elements.canvas;
       var ctx = canvas.getContext("2d");
 
-      var imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      // 1. Save current content synchronously in a temporary off-screen canvas at the START of resize
+      if (!resizeBaseCanvas) {
+        resizeBaseCanvas = document.createElement('canvas');
+        resizeBaseCanvas.width = canvas.width;
+        resizeBaseCanvas.height = canvas.height;
+        resizeBaseCanvas.getContext('2d').drawImage(canvas, 0, 0);
+      }
 
-      canvas.width = window.innerWidth * window.devicePixelRatio;
-      canvas.height = window.innerHeight * window.devicePixelRatio;
+      // 2. Compute new size
+      var newWidth = window.innerWidth;
+      var newHeight = window.innerHeight - 55;
 
-      canvas.style.width = window.innerWidth + "px";
-      canvas.style.height = window.innerHeight + "px";
+      // 3. Update Paper.js view size (this automatically resizes the canvas buffer)
+      if (typeof paper !== 'undefined' && paper.view) {
+        paper.view.viewSize = new paper.Size(newWidth, newHeight);
+        // Prevent Paper.js from clearing the canvas since we use manual drawing
+        paper.view.autoUpdate = false;
+      }
 
-      ctx.putImageData(imageData, 0, 0);
-      });
+      // 4. Update CSS size
+      canvas.style.width = newWidth + "px";
+      canvas.style.height = newHeight + "px";
+
+      // 6. Reset transform and enable high-quality smoothing
+      // This prevents the "zoom" effect and ensures any future scaling is smooth
+      ctx.setTransform(1, 0, 0, 1, 0, 0);
+      ctx.imageSmoothingEnabled = true;
+      ctx.imageSmoothingQuality = 'high';
+      ctx.mozImageSmoothingEnabled = true;
+      ctx.webkitImageSmoothingEnabled = true;
+      ctx.msImageSmoothingEnabled = true;
+
+      // 7. Fill with white background
+      ctx.fillStyle = "#ffffff";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+
+      // 8. Restore content from the BASE canvas and scale to fit the new size
+      // This ensures the drawing stretches to fill the window while staying sharp
+      ctx.drawImage(resizeBaseCanvas, 0, 0, canvas.width, canvas.height);
+
+      // 9. Reset the base canvas after a period of inactivity (resize finished)
+      if (resizeTimeout) {
+        clearTimeout(resizeTimeout);
+      }
+      resizeTimeout = setTimeout(function () {
+        resizeBaseCanvas = null;
+      }, 500);
     });
+  });
 });

--- a/activities/Paint.activity/js/paint-app.js
+++ b/activities/Paint.activity/js/paint-app.js
@@ -1,5 +1,5 @@
 /* PaintApp is a big object containing UI stuff, libraries and helpers */
-define([], function() {
+define([], function () {
   /* Function to disable all active class inside the toolbar */
   function paletteRemoveActiveClass() {
     for (var i = 0; i < PaintApp.paletteModesButtons.length; i++) {
@@ -26,9 +26,13 @@ define([], function() {
 
   /* Clear the canvas */
   function clearCanvas() {
-    var ctx = PaintApp.elements.canvas.getContext('2d');
-    ctx.fillStyle = "#ffffff"
-    ctx.fillRect(0, 0, parseInt(PaintApp.elements.canvas.style.width), parseInt(PaintApp.elements.canvas.style.height));
+    var canvas = PaintApp.elements.canvas;
+    var ctx = canvas.getContext('2d');
+    ctx.save();
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.fillStyle = "#ffffff";
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    ctx.restore();
     PaintApp.saveCanvas();
   }
 
@@ -48,7 +52,7 @@ define([], function() {
     var imgSrc2 = PaintApp.data.history.undo[PaintApp.data.history.undo.length - 1];
 
     /* Loading of the image stored in history */
-    img.onload = function() {
+    img.onload = function () {
       ctx.save();
       ctx.setTransform(1, 0, 0, 1, 0, 0);
       ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -98,7 +102,7 @@ define([], function() {
     var imgSrc = PaintApp.data.history.redo[PaintApp.data.history.redo.length - 1];
 
     /* Loading of the image stored in history */
-    img.onload = function() {
+    img.onload = function () {
       ctx.save();
       ctx.setTransform(1, 0, 0, 1, 0, 0);
       ctx.clearRect(0, 0, canvas.width, canvas.height);
@@ -116,7 +120,7 @@ define([], function() {
               src: PaintApp.collaboration.compress(PaintApp.elements.canvas.toDataURL())
             }
           });
-        } catch (e) {}
+        } catch (e) { }
       }
     };
     img.src = imgSrc;
@@ -162,7 +166,7 @@ define([], function() {
     var canvas = PaintApp.elements.canvas;
     try {
       var image = canvas.toDataURL();
-    } catch (e) {}
+    } catch (e) { }
 
     /* If doing a new action, setting redo to an empty list */
     if ((PaintApp.data.history.undo.length > 0 && PaintApp.data.history.undo[PaintApp.data.history.undo.length - 1] !== image) || (PaintApp.data.history.undo.length === 0)) {


### PR DESCRIPTION
The Paint activity only measured canvas size at startup.
When the window was resized, the canvas did not expand, leaving an inactive white area.

This fix updates canvas dimensions dynamically when the window size changes.

Fixes #1944 