### PR TITLE
Fix: Fix for issue #1944 (Paint canvas does not resize)

### DIFF
--- a/activities/Paint.activity/js/activity.js
+++ b/activities/Paint.activity/js/activity.js
@@ -55,7 +55,7 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activit
     // Export as PNG image
     document.getElementById("save-image-button").addEventListener('click', function () {
       var mimetype = 'image/png';
-      var inputData = document.getElementById("paint-canvas").toDataURL(mimetype, 1);
+      var inputData =PaintApp.data.worldCanvas.toDataURL(mimetype, 1);
       var metadata = {
         mimetype: mimetype,
         title: l10n.get("PaintBy", { name: currentenv.user.name }),
@@ -66,19 +66,18 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activit
       };
       datastore.create(metadata, function () {
         humane.log(l10n.get('PaintImageSaved'))
-        console.log("export done.")
       }, inputData);
     });
 
     document.getElementById("stop-button").addEventListener('click', function(event) {
+      PaintApp.data.worldCanvas.getContext('2d').drawImage(PaintApp.elements.canvas, 0, 0,PaintApp.prevScreenWidth,PaintApp.prevScreenHeight);
       var data = {
-        width: PaintApp.elements.canvas.width / window.devicePixelRatio,
-        height: PaintApp.elements.canvas.height / window.devicePixelRatio,
-        src: PaintApp.collaboration.compress(PaintApp.elements.canvas.toDataURL())
+        width: PaintApp.data.worldCanvas.width / window.devicePixelRatio,
+        height: PaintApp.data.worldCanvas.height / window.devicePixelRatio,
+        src: PaintApp.collaboration.compress(PaintApp.data.worldCanvas.toDataURL())
       }
-
       var jsonData = JSON.stringify(data);
-
+      
       activity.getDatastoreObject().setDataAsText(jsonData);
       activity.getDatastoreObject().save(function(error) {});
     });
@@ -97,9 +96,11 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activit
         PaintApp.clearCanvas();
         img = new Image();
         img.onload = function() {
-          PaintApp.elements.canvas.getContext('2d').drawImage(img, 0, 0, data.width, data.height);
+         
+          PaintApp.data.worldCanvas.getContext('2d').drawImage(img, 0, 0, data.width, data.height);
+          PaintApp.elements.canvas.getContext('2d').drawImage(PaintApp.data.worldCanvas,0,0,window.innerWidth,window.innerHeight-55,0,0,window.innerWidth,window.innerHeight-55);
           PaintApp.saveCanvas();
-        };
+        };    
         img.src = PaintApp.collaboration.decompress(data.src);
         //DISPLAY
       });

--- a/activities/Paint.activity/js/activity.js
+++ b/activities/Paint.activity/js/activity.js
@@ -93,10 +93,14 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activit
           return;
         }
         var data = JSON.parse(jsonData);
+        console.log(data,"Hi IM here ")
+        PaintApp.data.worldCanvas.width=data.width
+        PaintApp.data.worldCanvas.height=data.height
+        PaintApp.data.worldCanvas.style.width = data.width+"px";
+        PaintApp.data.worldCanvas.style.height = data.height+"px";
         PaintApp.clearCanvas();
         img = new Image();
         img.onload = function() {
-         
           PaintApp.data.worldCanvas.getContext('2d').drawImage(img, 0, 0, data.width, data.height);
           PaintApp.elements.canvas.getContext('2d').drawImage(PaintApp.data.worldCanvas,0,0,window.innerWidth,window.innerHeight-55,0,0,window.innerWidth,window.innerHeight-55);
           PaintApp.saveCanvas();

--- a/activities/Paint.activity/js/activity.js
+++ b/activities/Paint.activity/js/activity.js
@@ -93,7 +93,6 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env","activit
           return;
         }
         var data = JSON.parse(jsonData);
-        console.log(data,"Hi IM here ")
         PaintApp.data.worldCanvas.width=data.width
         PaintApp.data.worldCanvas.height=data.height
         PaintApp.data.worldCanvas.style.width = data.width+"px";

--- a/activities/Paint.activity/js/modes/modes-bucket.js
+++ b/activities/Paint.activity/js/modes/modes-bucket.js
@@ -86,7 +86,7 @@ define([], function() {
       if (PaintApp.modes.Bucket.lock) {
         return;
       }
-      var ctx = PaintApp.elements.canvas.getContext('2d');
+      var ctx = PaintApp.data.worldCanvas.getContext('2d');
 
       /* Transformation of the color used inside the palette to match with the bucket fill functions prototypes */
       var colorFillStrings = PaintApp.data.color.fill.slice(4, -1).split(',');
@@ -119,7 +119,7 @@ define([], function() {
       }
       /* Proceed with the bucket fill */
       floodfill(parseInt(event.point.x * window.devicePixelRatio), parseInt(event.point.y * window.devicePixelRatio), fillColor, ctx, ctx.canvas.width, ctx.canvas.height, 5);
-
+       PaintApp.elements.canvas.getContext('2d').drawImage(PaintApp.data.worldCanvas,0,0,window.innerWidth,window.innerHeight-55,0,0,window.innerWidth,window.innerHeight-55);
 
       PaintApp.saveCanvas();
       PaintApp.modes.Bucket.lock = false;
@@ -130,9 +130,9 @@ define([], function() {
           PaintApp.collaboration.sendMessage({
             action: 'toDataURL',
             data: {
-              width: PaintApp.elements.canvas.width / window.devicePixelRatio,
-              height: PaintApp.elements.canvas.height / window.devicePixelRatio,
-              src: PaintApp.collaboration.compress(PaintApp.elements.canvas.toDataURL())
+              width: PaintApp.data.worldCanvas.width / window.devicePixelRatio,
+              height: PaintApp.data.worldCanvas.height / window.devicePixelRatio,
+              src: PaintApp.collaboration.compress(PaintApp.data.worldCanvas.toDataURL())
             }
           })
         } catch (e) {}

--- a/activities/Paint.activity/js/paint-activity.js
+++ b/activities/Paint.activity/js/paint-activity.js
@@ -42,7 +42,9 @@ function initGui() {
 
   /* Scrolling top prevent any overflow */
   window.scrollTo(0, -1000);
+  PaintApp.clearCanvas();
 
+  
   /* Created a World Canvas As Big As the screen to Keep track of Drawings outside the Window When Resized*/
   PaintApp.prevScreenWidth=parseInt(window.innerWidth);
   PaintApp.prevScreenHeight=parseInt(window.innerHeight) - 55;

--- a/activities/Paint.activity/js/paint-activity.js
+++ b/activities/Paint.activity/js/paint-activity.js
@@ -65,8 +65,8 @@ function canvasResize() {
   paper.view.viewSize = new paper.Size(newWidth, newHeight);
   PaintApp.prevScreenHeight = parseInt(window.innerHeight) - 55;
   PaintApp.prevScreenWidth = parseInt(window.innerWidth);
-  canvas.width = newWidth;
-  canvas.height = newHeight;
+  canvas.style.width = newWidth+"px";
+  canvas.style.height = newHeight+"px";
   canvas.getContext('2d').drawImage(worldCanvas,0,0,newWidth,newHeight,0,0,newWidth,newHeight);
 }
 window.addEventListener("resize", canvasResize);

--- a/activities/Paint.activity/js/paint-activity.js
+++ b/activities/Paint.activity/js/paint-activity.js
@@ -43,8 +43,32 @@ function initGui() {
   /* Scrolling top prevent any overflow */
   window.scrollTo(0, -1000);
 
-  PaintApp.clearCanvas();
+  /* Created a World Canvas As Big As the screen to Keep track of Drawings outside the Window When Resized*/
+  PaintApp.prevScreenWidth=parseInt(window.innerWidth);
+  PaintApp.prevScreenHeight=parseInt(window.innerHeight) - 55;
+
+  const worldCanvas = document.createElement('canvas');
+  worldCanvas.width = parseInt(screen.width);
+  worldCanvas.height = parseInt(screen.height);
+  PaintApp.data.worldCanvas = worldCanvas;
+
 }
+/* The initial drawing is transferred to a world canvas, from which only the visible portion is rendered onto the main canvas. */
+function canvasResize() {
+  const canvas=PaintApp.elements.canvas
+  const worldCanvas=PaintApp.data.worldCanvas
+  const newWidth = parseInt(window.innerWidth);
+  const newHeight = parseInt(window.innerHeight) - 55;
+  worldCanvas.getContext('2d').drawImage(canvas, 0, 0,PaintApp.prevScreenWidth,PaintApp.prevScreenHeight);
+  paper.view.viewSize = new paper.Size(newWidth, newHeight);
+  PaintApp.prevScreenHeight = parseInt(window.innerHeight) - 55;
+  PaintApp.prevScreenWidth = parseInt(window.innerWidth);
+  canvas.width = newWidth;
+  canvas.height = newHeight;
+  canvas.getContext('2d').drawImage(worldCanvas,0,0,newWidth,newHeight,0,0,newWidth,newHeight);
+}
+window.addEventListener("resize", canvasResize);
+
 
 /* Initialization of the presence palette */
 function initPresencePalette() {

--- a/activities/Paint.activity/js/paint-activity.js
+++ b/activities/Paint.activity/js/paint-activity.js
@@ -50,11 +50,12 @@ function initGui() {
   PaintApp.prevScreenHeight=parseInt(window.innerHeight) - 55;
 
   const worldCanvas = document.createElement('canvas');
-  worldCanvas.width = parseInt(screen.width);
-  worldCanvas.height = parseInt(screen.height);
+  worldCanvas.width = 2000
+  worldCanvas.height = 2000
   PaintApp.data.worldCanvas = worldCanvas;
 
 }
+
 /* The initial drawing is transferred to a world canvas, from which only the visible portion is rendered onto the main canvas. */
 function canvasResize() {
   const canvas=PaintApp.elements.canvas
@@ -67,10 +68,11 @@ function canvasResize() {
   PaintApp.prevScreenWidth = parseInt(window.innerWidth);
   canvas.style.width = newWidth+"px";
   canvas.style.height = newHeight+"px";
-  canvas.getContext('2d').drawImage(worldCanvas,0,0,newWidth,newHeight,0,0,newWidth,newHeight);
+     PaintApp.elements.canvas.width=newWidth;
+   PaintApp.elements.canvas.height=newHeight;
+   PaintApp.elements.canvas.getContext('2d').drawImage(worldCanvas,0,0,newWidth,newHeight,0,0,newWidth,newHeight);
 }
 window.addEventListener("resize", canvasResize);
-
 
 /* Initialization of the presence palette */
 function initPresencePalette() {

--- a/activities/Paint.activity/js/paint-activity.js
+++ b/activities/Paint.activity/js/paint-activity.js
@@ -50,8 +50,8 @@ function initGui() {
   PaintApp.prevScreenHeight=parseInt(window.innerHeight) - 55;
 
   const worldCanvas = document.createElement('canvas');
-  worldCanvas.width = 2000
-  worldCanvas.height = 2000
+  worldCanvas.width = screen.width
+  worldCanvas.height = screen.height
   PaintApp.data.worldCanvas = worldCanvas;
 
 }

--- a/activities/Paint.activity/js/paint-app.js
+++ b/activities/Paint.activity/js/paint-app.js
@@ -54,7 +54,6 @@ define([], function() {
     var img = new Image();
     var imgSrc = PaintApp.data.history.undo[PaintApp.data.history.undo.length - 2];
     var imgSrc2 = PaintApp.data.history.undo[PaintApp.data.history.undo.length - 1];
-    console.log(imgSrc,"High Way to hell")
     /* Loading of the image stored in history */
     img.onload = function() {
       worldCtx.save();
@@ -181,7 +180,6 @@ define([], function() {
     try {
       
       var image = canvas.toDataURL();
-      console.log(image,canvas,"Premamam")
     } catch (e) {}
 
     /* If doing a new action, setting redo to an empty list */

--- a/activities/Paint.activity/js/paint-app.js
+++ b/activities/Paint.activity/js/paint-app.js
@@ -27,9 +27,15 @@ define([], function() {
   /* Clear the canvas */
   function clearCanvas() {
     var ctx = PaintApp.elements.canvas.getContext('2d');
+    const worldCanvas=PaintApp.data.worldCanvas
     ctx.fillStyle = "#ffffff"
     ctx.fillRect(0, 0, parseInt(PaintApp.elements.canvas.style.width), parseInt(PaintApp.elements.canvas.style.height));
-    PaintApp.saveCanvas();
+    
+    if(worldCanvas){
+      worldCanvas.getContext('2d').fillStyle = "#ffffff"
+      worldCanvas.getContext('2d').fillRect(0, 0, parseInt(worldCanvas.width), parseInt(worldCanvas.height));
+    }
+      PaintApp.saveCanvas();
   }
 
   /* Trigger undo click, undo using the history */
@@ -41,29 +47,33 @@ define([], function() {
     }
 
     PaintApp.modes.Pen.point = undefined;
+    var worldCanvas = PaintApp.data.worldCanvas;
     var canvas = PaintApp.elements.canvas;
+    var worldCtx = worldCanvas.getContext('2d');
     var ctx = canvas.getContext('2d');
     var img = new Image();
     var imgSrc = PaintApp.data.history.undo[PaintApp.data.history.undo.length - 2];
     var imgSrc2 = PaintApp.data.history.undo[PaintApp.data.history.undo.length - 1];
-
+    console.log(imgSrc,"High Way to hell")
     /* Loading of the image stored in history */
     img.onload = function() {
-      ctx.save();
-      ctx.setTransform(1, 0, 0, 1, 0, 0);
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.drawImage(img, 0, 0);
-      ctx.restore();
-
+      worldCtx.save();
+      worldCtx.setTransform(1, 0, 0, 1, 0, 0);
+      worldCtx.clearRect(0, 0, worldCanvas.width, worldCanvas.height);
+      worldCtx.drawImage(img, 0, 0);
+      worldCtx.restore();
+      ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+      ctx.drawImage(worldCanvas,0,0,window.innerWidth,window.innerHeight-55,0,0,window.innerWidth,window.innerHeight-55);
+      ctx.restore()
       /* If the activity is shared, will send the instruction to everyone */
       if (PaintApp.data.isShared) {
         try {
           PaintApp.collaboration.sendMessage({
             action: 'toDataURL',
             data: {
-              width: PaintApp.elements.canvas.width / window.devicePixelRatio,
-              height: PaintApp.elements.canvas.height / window.devicePixelRatio,
-              src: PaintApp.collaboration.compress(PaintApp.elements.canvas.toDataURL())
+              width: worldCanvas.width/ window.devicePixelRatio,
+              height: worldCanvas.height/ window.devicePixelRatio,
+              src: PaintApp.collaboration.compress(worldCanvas.toDataURL())
             }
           });
         } catch (e) {
@@ -73,7 +83,7 @@ define([], function() {
 
     };
     img.src = imgSrc;
-
+    
     PaintApp.data.history.redo.push(imgSrc2);
     PaintApp.data.history.undo.pop();
 
@@ -92,35 +102,39 @@ define([], function() {
     }
 
     PaintApp.modes.Pen.point = undefined;
+    var worldCanvas = PaintApp.data.worldCanvas;
     var canvas = PaintApp.elements.canvas;
-    var ctx = canvas.getContext('2d');
+    var ctx=canvas.getContext('2d');
+    var worldCtx = worldCanvas.getContext('2d');
     var img = new Image();
     var imgSrc = PaintApp.data.history.redo[PaintApp.data.history.redo.length - 1];
 
     /* Loading of the image stored in history */
     img.onload = function() {
-      ctx.save();
-      ctx.setTransform(1, 0, 0, 1, 0, 0);
-      ctx.clearRect(0, 0, canvas.width, canvas.height);
-      ctx.drawImage(img, 0, 0);
-      ctx.restore();
-
+      worldCtx.save();
+      worldCtx.setTransform(1, 0, 0, 1, 0, 0);
+      worldCtx.clearRect(0, 0, worldCanvas.width, worldCanvas.height);
+      worldCtx.drawImage(img, 0, 0);
+      worldCtx.restore();
+      ctx.clearRect(0, 0, window.innerWidth, window.innerHeight);
+      ctx.drawImage(worldCanvas,0,0,window.innerWidth,window.innerHeight-55,0,0,window.innerWidth,window.innerHeight-55);
+      ctx.restore()
       /* If the activity is shared, will send the instruction to everyone */
       if (PaintApp.data.isShared) {
         try {
           PaintApp.collaboration.sendMessage({
             action: 'toDataURL',
             data: {
-              width: PaintApp.elements.canvas.width / window.devicePixelRatio,
-              height: PaintApp.elements.canvas.height / window.devicePixelRatio,
-              src: PaintApp.collaboration.compress(PaintApp.elements.canvas.toDataURL())
+              width: worldCanvas.width / window.devicePixelRatio,
+              height:worldCanvas.height / window.devicePixelRatio,
+              src: PaintApp.collaboration.compress(PaintApp.data.worldCanvas.toDataURL())
             }
           });
         } catch (e) {}
       }
     };
     img.src = imgSrc;
-
+   
     PaintApp.data.history.undo.push(imgSrc);
     PaintApp.data.history.redo.pop();
 
@@ -134,7 +148,6 @@ define([], function() {
   function displayUndoRedoButtons() {
     var notAvailableOpacity = '0.4';
     var availableOpacity = '1';
-
     /* If activity is shared and we are not the host we cannot do undo/redo */
     if (PaintApp.data.isShared && !PaintApp.data.isHost) {
       PaintApp.elements.redoButton.style.opacity = notAvailableOpacity;
@@ -159,9 +172,16 @@ define([], function() {
 
   /* Storing canvas onto history */
   function saveCanvas() {
+
     var canvas = PaintApp.elements.canvas;
+    if(PaintApp.data.worldCanvas)  
+      {canvas=PaintApp.data.worldCanvas
+        canvas.getContext('2d').drawImage(PaintApp.elements.canvas, 0, 0,PaintApp.prevScreenWidth,PaintApp.prevScreenHeight);
+      }
     try {
+      
       var image = canvas.toDataURL();
+      console.log(image,canvas,"Premamam")
     } catch (e) {}
 
     /* If doing a new action, setting redo to an empty list */


### PR DESCRIPTION
# Summary 
This PR is an Fix for #1944 where the canvas is not resized properly when the window dimensions Changes

# Issue
Initially the Paint activity only measures the screen size when it starts. if it is opened in a small window and later resized the canvas does not expand to fit the new space. this creates a white area that looks like part of the canvas but is actually inactive background so drawing, pasting, or adding images in that area has no effect.

# Fix
Normally, simply expanding the canvas doesn’t work, because resizing it directly will reset its contents. To solve this, a reference canvas is used: when resizing, the current image is first copied onto the reference canvas, and then the main canvas is resized. The reference canvas is also useful for keeping track of elements that extend beyond the visible canvas area when the window becomes smaller.

# Before

https://github.com/user-attachments/assets/c6cd421a-5b98-44ca-adae-9dfc96df159b

After

https://github.com/user-attachments/assets/42969baf-1e63-4159-9803-8083dc6b6547

