### PR TITLE
Fix: Hide filter button when no categories are available

### DIFF
--- a/activities/VideoViewer.activity/js/activity.js
+++ b/activities/VideoViewer.activity/js/activity.js
@@ -17,6 +17,10 @@ define(["sugar-web/activity/activity","sugar-web/env","filterpalette","tutorial"
 
 		// Create palette
 		var filterButton = document.getElementById("filter-button");
+		
+		// Hide filter initially until categories are available
+		filterButton.style.display = "none";
+		
 		filterpalette = new filterpalette.FilterPalette(filterButton, undefined);
 		filterpalette.addEventListener('filter', function() {
 			app.setFilter({category: filterpalette.getFilter()});


### PR DESCRIPTION
The filter option was always visible even when selected libraries
did not provide category metadata (e.g., Khan Academy, Art4Apps).

This change hides the filter button initially and prepares it to
be shown only when categories are available, improving UX for children.