### PR TITLE
Fixing snake spawning too close to the player and sprite clipping

### DIFF
--- a/activities/FoodChain.activity/playgame.js
+++ b/activities/FoodChain.activity/playgame.js
@@ -197,6 +197,7 @@ enyo.kind({
 				width: FoodChain.sprites.snake.dx, height: FoodChain.sprites.snake.dy, index: 0, sound: "audio/snake"
 			});
 			snake.alive = false;
+			snake.spawnedOnce = false;
 			this.snakes.push(snake);
 		}
 
@@ -481,7 +482,15 @@ enyo.kind({
 			if (!currentsnake.alive) {
 
 				// Compute trajectory free of rock & snakes interval
-				var spritesToAvoid = enyo.cloneArray(this.rocks).concat(this.snakes);
+				if (!currentsnake.spawnedOnce) {
+					// If spawnedOnce is false it's the first time we decide where to spawn this specific snake
+					// So we should avoid the frog since it would be at the spawn
+					var spritesToAvoid = enyo.cloneArray(this.rocks).concat(this.snakes).concat(this.frog);
+				}
+				else {
+					var spritesToAvoid = enyo.cloneArray(this.rocks).concat(this.snakes);
+				}
+
 				var freeInterval = [];
 				for (var x = 100 ; x < FoodChain.playArea.width-300 ; x = x + 50) {
 					// Compute is this interval is free
@@ -499,6 +508,11 @@ enyo.kind({
 					if (free)
 					freeInterval.push(x);
 				}
+				
+				// If there is nowhere to spawn, skip this spawn attempt for now
+				if (freeInterval.length === 0) {
+					continue;
+				}
 
 				// Compute the snake position
 				x = freeInterval[Math.floor(Math.random()*freeInterval.length)];
@@ -510,6 +524,7 @@ enyo.kind({
 				currentsnake.setY(y);
 				currentsnake.setHeading(h);
 				currentsnake.alive = true;
+				currentsnake.spawnedOnce = true;
 				currentsnake.playSound();
 				var dy = (currentsnake.getHeading() == 90) ? -6 : 6;
 				currentsnake.animate(this.ctx, [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7], 0, dy, enyo.bind(this, "snakeCollisionEngine"));


### PR DESCRIPTION
As of right now I have fixed the first issue I pointed out.
Now the first time a snake spawn it wont' be near the position of the player (which will be at the spawn).

I also added a check that in case a snake can't find a free space to spawn in, we wait to the next iteration.
I would like to note that this issue was also present in the original version, you can try it by yourself by increasing the number of stones to +10, and you'll see than when snakes have nowhere to spawn they get teleport
at the top left of the map, with their animation clipping into one another.