### PR TITLE
Fix eraser tool sending wrong coordinates in shared sessions

### DIFF
--- a/activities/Paint.activity/js/modes/modes-eraser.js
+++ b/activities/Paint.activity/js/modes/modes-eraser.js
@@ -71,9 +71,11 @@ define([], function() {
             lineWidth: PaintApp.data.size,
             lineCap: 'round',
             strokeStyle: '#fff',
+            /*Use the previously tracked eraser position instead of the current point,
+             so collaborators receive correctly connected stroke segments */
             from: {
-              x: event.point.x + 1,
-              y: event.point.y + 1
+              x: PaintApp.modes.Eraser.point.x,
+              y: PaintApp.modes.Eraser.point.y
             },
             to: {
               x: event.point.x,


### PR DESCRIPTION
Fixes #2022

In modes-eraser.js, the onMouseDrag function was using event.point.x + 1  and event.point.y + 1 as the from coordinates when broadcasting to  collaborators. 

Fixed by using PaintApp.modes.Eraser.point.x and PaintApp.modes.Eraser.point.y instead, matching how modes-pen.js handles the same thing.