### PR TITLE
Fix TankOp enemy tanks moving 2 positions per turn

### DIFF
--- a/activities/TankOp.activity/play.js
+++ b/activities/TankOp.activity/play.js
@@ -496,7 +496,6 @@ enyo.kind({
 			that.heading = util.random(4);
 			next = util.nextPositionOnHeading(that);
 		}
-		next = util.nextPositionOnHeading(that);
 		that.x = next.x;
 		that.y = next.y;
 	}


### PR DESCRIPTION

Fixes #2078 