### PR TITLE
Fix: prevent crash when jsonData is null in dictstore.js

### DIFF
--- a/activities/3DVolume.activity/lib/sugar-web/dictstore.js
+++ b/activities/3DVolume.activity/lib/sugar-web/dictstore.js
@@ -31,7 +31,7 @@ define(["sugar-web/activity/activity", "sugar-web/env"], function (activity, env
             localStorage.clear();
 
             var onLoaded = function (error, metadata, jsonData) {
-                var data = JSON.parse(jsonData);
+                var data = JSON.parse(jsonData || "{}");
                 for (var i in data) {
                     localStorage[i] = data[i];
                 }


### PR DESCRIPTION
This PR adds a null check to the JSON.parse call in js/dictstore.js. When the Datastore is empty, jsonData returns null, causing a crash. Adding a fallback empty object string "{}" ensures the app initializes safely.