### PR TITLE
Fix(curriculum): achievements blank page from TypeError

### DIFF
--- a/activities/Curriculum.activity/js/components/SugarL10n.js
+++ b/activities/Curriculum.activity/js/components/SugarL10n.js
@@ -120,7 +120,7 @@ Vue.component('sugar-localization', {
 		// Convert a UNIX timestamp to Sugarizer time elapsed string
 		localizeTimestamp: function (timestamp) {
 			const maxlevel = 2;
-			const levels = 0;
+			let levels = 0;
 			let time_period = '';
 			let elapsed_seconds = (Date.now() - timestamp) / 1000;
 			for (let i = 0; i < this.units.length; i++) {


### PR DESCRIPTION
Fixes #2073 

This PR fixes the blank white screen when visiting the achievements page in the Curriculum Activity once proofs are uploaded. 
The problem is due to the `localizeTimestamp` function in `Curriculum.activity/js/components/SugarL10n.js` attempting to reassign a `const` varible. 
The fix includes initializing `levels` variable to `let`.