### PR TITLE
fix(GetThingsDone): handle null or invalid datastore data before JSON…

### DIFF
--- a/activities/GetThingsDone.activity/js/activity.js
+++ b/activities/GetThingsDone.activity/js/activity.js
@@ -99,7 +99,15 @@ define(["sugar-web/activity/activity","l10n","sugar-web/datastore","activity/mod
         todo = new Todo();
         var datastoreObject = activity.getDatastoreObject();
         function onLoaded(error, metadata, data) {
-            todo.controller.loadItems(JSON.parse(data));
+            let parsed = [];
+
+            try {
+                parsed = data ? JSON.parse(data) : [];
+            } catch (e) {
+                console.warn("Invalid JSON data:", e);
+            }
+
+            todo.controller.loadItems(parsed);
         }
         datastoreObject.loadAsText(onLoaded);
         var input = document.getElementById("new-todo");


### PR DESCRIPTION
Fixes #2076

Handle null or invalid datastore data before calling JSON.parse in GetThingsDone.

This prevents a runtime error when the activity loads with empty, missing, or malformed saved data.

Tested with valid saved todos and with null data fallback.