### PR TITLE
fix(Flip): refrain usage of setSize to avoid game reset

### DIFF
--- a/activities/Flip.activity/js/game.js
+++ b/activities/Flip.activity/js/game.js
@@ -326,19 +326,6 @@ function Game(stage,xocolor,doc,datastore,activity,sizepalette){
 			this.restoreFromDatastore(data);
 
 			//Restore saved data from datastore
-			this.stack = data.stack;
-			this.startgridwidth = data.startgridwidth;
-			this.startgridheight = data.startgridheight;
-			this.setSize(data.startgridheight);
-			this.turns = data.turns;
-			document.getElementById("turnno").innerHTML = " " + (this.turns);
-			document.getElementById("fliptext").style.borderBottom = data.indcolour;
-			clearTimeout(this.newGameTimeout);
-			clearTimeout(this.solveTimeout);
-			stage.removeAllChildren();
-			this.calculateDimensions();
-			this.initDots(data.dots);
-
 		} else {
 			this.newGame();
 		}
@@ -348,6 +335,9 @@ function Game(stage,xocolor,doc,datastore,activity,sizepalette){
 		this.stack = data.stack;
 		this.startgridwidth = data.startgridwidth;
 		this.startgridheight = data.startgridheight;
+		this.setGridDimension(data.startgridheight);
+		this.palette.setUsed();
+		this.level = data.level;
 		this.turns = data.turns;
 		document.getElementById("fliptext").style.borderBottom = data.indcolour;
 		clearTimeout(this.newGameTimeout);

--- a/activities/Flip.activity/js/game.js
+++ b/activities/Flip.activity/js/game.js
@@ -345,5 +345,7 @@ function Game(stage,xocolor,doc,datastore,activity,sizepalette){
 		stage.removeAllChildren();
 		this.calculateDimensions();
 		this.initDots(data.dots);
+		document.getElementById("turnno").innerHTML = " " + (this.turns);
+		this.drawIndicator();
 	}
 }

--- a/main.js
+++ b/main.js
@@ -63,16 +63,16 @@ function LoadFile(event, file) {
 		var text = json
 			? data
 			: "data:" +
-			  fileProperty.type +
-			  ";base64," +
-			  data.toString("base64");
+			fileProperty.type +
+			";base64," +
+			data.toString("base64");
 		event.sender.send("choose-files-reply", fileProperty, err, text);
 	});
 }
 
 // Generate a fake UUID v4
 function uuidv4() {
-	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
 		var r = Math.random() * 16 | 0,
 			v = c === 'x' ? r : (r & 0x3 | 0x8);
 		return v.toString(16);
@@ -134,16 +134,16 @@ function createWindow() {
 	if (process.platform === "darwin") {
 		app.dock.setIcon(app.getAppPath() + "/res/icon/electron/icon-1024.png");
 	}
-
+	mainWindow.webContents.openDevTools();
 	// Load the index.html of Sugarizer
 	mainWindow.loadURL(
 		launch
 			? launch
 			: "file://" +
-					app.getAppPath() +
-					"/index.html" +
-					(reinit ? "?rst=1" : "") +
-					(logoff ? "?rst=2" : "")
+			app.getAppPath() +
+			"/index.html" +
+			(reinit ? "?rst=1" : "") +
+			(logoff ? "?rst=2" : "")
 	);
 	if (frameless) {
 		mainWindow.maximize();

--- a/main.js
+++ b/main.js
@@ -63,16 +63,16 @@ function LoadFile(event, file) {
 		var text = json
 			? data
 			: "data:" +
-			fileProperty.type +
-			";base64," +
-			data.toString("base64");
+			  fileProperty.type +
+			  ";base64," +
+			  data.toString("base64");
 		event.sender.send("choose-files-reply", fileProperty, err, text);
 	});
 }
 
 // Generate a fake UUID v4
 function uuidv4() {
-	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+	return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
 		var r = Math.random() * 16 | 0,
 			v = c === 'x' ? r : (r & 0x3 | 0x8);
 		return v.toString(16);
@@ -134,16 +134,16 @@ function createWindow() {
 	if (process.platform === "darwin") {
 		app.dock.setIcon(app.getAppPath() + "/res/icon/electron/icon-1024.png");
 	}
-	mainWindow.webContents.openDevTools();
+
 	// Load the index.html of Sugarizer
 	mainWindow.loadURL(
 		launch
 			? launch
 			: "file://" +
-			app.getAppPath() +
-			"/index.html" +
-			(reinit ? "?rst=1" : "") +
-			(logoff ? "?rst=2" : "")
+					app.getAppPath() +
+					"/index.html" +
+					(reinit ? "?rst=1" : "") +
+					(logoff ? "?rst=2" : "")
 	);
 	if (frameless) {
 		mainWindow.maximize();


### PR DESCRIPTION
Fixes part of #2083

Fix issues in Flip activity when reopening:

- Grid size UI did not reflect saved state
- Auto-solve (robot) stopped prematurely after reopening

Root cause:
State restoration triggered palette.setSize() ->calls game.setSize() -> resets the game via newGame(), clearing the solve stack.

## Fix:
- Use `restoreFromDatastore` as single source of truth
- Remove duplicate restoration logic
- Avoid calling palette.setSize during restore
- Use `palette.setUsed` to update UI without triggering game logic

https://github.com/user-attachments/assets/f88ab040-c274-4325-8607-f398895a065c


