### PR TITLE
Fix: Clear animation interval on stop to prevent Speak Activity memory leak

### DIFF
--- a/activities/Speak.activity/js/SpeakActivity.js
+++ b/activities/Speak.activity/js/SpeakActivity.js
@@ -72,9 +72,12 @@ define(["sugar-web/graphics/palette","sugar-web/env","l10n","sugar-web/datastore
 				document.captureEvents(Event.MOUSEMOVE)
 			}
 			var FPS = 30;
-			setInterval(function() {
+			var canvasInterval = setInterval(function() {
 			  updateCanvas();
 			}, 1000/FPS);
+			document.getElementById("stop-button").addEventListener('click', function() {
+				clearInterval(canvasInterval);
+			});
 			window.addEventListener('localized', function() {
 				if (first) {
 					l10n.init(sugarSettings.language);


### PR DESCRIPTION
### Problem
In the Speak Activity (`SpeakActivity.js`), a `setInterval` was used to run a 30 FPS canvas animation loop, but its return ID was not stored. As a result, the interval could not be cleared when the activity was closed via the stop button. This caused the animation loop to continue running in the background, leading to unnecessary CPU usage and a potential memory leak.

### Solution
- Captured the `setInterval` return ID in a new variable called `canvasInterval`.
- Added an event listener triggered by the `stop-button` to correctly run `clearInterval(canvasInterval)` when the user hits stop, successfully cleaning up the animation pipeline and eliminating the memory leak.

### How to verify
1. Open the Speak activity. 
2. Play around with the face drawing interface. 
3. Stop the activity and profile the Javascript VM's memory. Memory usage should plateau normally and stop spiking, and the CPU footprint of the `updateCanvas` loop should vanish instead of continuing to run out of view.

fixes #2109 