### PR TITLE
Fix X and Y axis fields alignment in Chart Activity config toolbar

### DIFF
--- a/activities/Chart.activity/css/activity.css
+++ b/activities/Chart.activity/css/activity.css
@@ -301,8 +301,14 @@ p {
 
 #xLabel-button, #yLabel-button {
   	margin-left: 14px;
-  	transform: translateY(-6px);
   	width: 35px;
+}
+#config-toolbar {
+	display: flex;
+	align-items: center;
+}
+#config-toolbar .input-text {
+	margin-top: 0;
 }
 #xLabel-button {
     background-image: url(../icons/hlabel.svg);


### PR DESCRIPTION
Fixes #2103

This PR fixes the vertical alignment of the X and Y axis fields in the Chart Activity config toolbar, preventing them from touching the bottom edge.

Changes made:
- Removed `transform: translateY(-6px)` from the X and Y labels
- Added `display: flex; align-items: center;` to `#config-toolbar` for proper vertical centering
- Removed the `margin-top` from `#config-toolbar .input-text` as it pushed the fields too low

Tested locally and successfully verified that all elements in the config sub-toolbar are now perfectly vertically centered.