### PR TITLE
fix: undefined titles in Journal entries

### DIFF
--- a/activities/Chart.activity/js/activity.js
+++ b/activities/Chart.activity/js/activity.js
@@ -303,7 +303,8 @@ const app = new Vue({
 			this.LZ = this.SugarJournal.LZString;
 			if (metadata.mimetype === "text/csv") {
 				this.isCsvFile = true;
-				this.csvTitle = this.currentenv.activityName;
+				this.csvTitle = metadata.title || (this.currentenv ? this.currentenv.activityName : "Chart Data.csv");
+                this.updateActivityTitle(this.csvTitle);
 				this.pref.chartType = "csvMode";
 				const json = CSVParser.csvToJson(data);
 				if (this.$refs.csvView) {

--- a/activities/Measure.activity/js/activity.js
+++ b/activities/Measure.activity/js/activity.js
@@ -858,9 +858,12 @@ var app = new Vue({
 			}
 
 			var vm = this;
+			var userName = (vm.currentenv && vm.currentenv.user && vm.currentenv.user.name) ? vm.currentenv.user.name : "Unknown";
+            var logTitle = this.SugarL10n.get("MeasureLoggingBy", { name: userName });
+            var csvTitle = logTitle ? logTitle + ".csv" : "Measure Data.csv";
 			var metadata = {
 				mimetype: "text/csv",
-				title: this.SugarL10n.get("MeasureLoggingBy", { name: vm.currentenv.user.name}) + ".csv",
+				title: csvTitle,
 				activity: "org.sugarlabs.ChartActivity",
 				timestamp: new Date().getTime(),
 				creation_time: new Date().getTime(),


### PR DESCRIPTION

**Title:** Fix "undefined" Journal title when opening CSV files in Chart Activity

**Issue:** #2097 

**Description:**

**What does this PR do?**
This PR fixes a bug where opening a previously exported CSV file from the Journal changes its entry title to "undefined". **This fix works for both the Sugarizer Electron (desktop) app and the Website version.**

**Root Cause:**
When a CSV file (such as one exported from the Measure Activity) is opened from the Journal, it is handled by the Chart Activity. Upon loading the CSV data, the activity was unintentionally overriding the entry's title using an internal activity name reference that comes back as undefined for external files. When the user closed the activity, this undefined value was saved back to the Journal, overwriting the original filename.

**Changes Made:**
* Updated the Journal data loading logic in the Chart Activity to prioritize the existing metadata title provided by the Journal when handling CSV files.
* Implemented fallback logic to ensure a valid default string is used if the metadata or internal environment properties are missing.
* Ensured the activity's internal title state is updated immediately upon loading so that the correct filename is preserved when the session is saved and closed.

**How to test:**
1. Open the Measure Activity.
2. Export the measure data as a CSV.
3. Go to the Journal and verify the CSV file has a valid title (e.g., "Measure Logging by ...").
4. Click on the CSV file to open it (it will open in the Chart Activity).
5. Stop/Close the Chart Activity.
6. Return to the Journal and verify that the title is still correctly preserved and has not been renamed to "undefined".

I verified this behavior on both the Electron app and the web version


https://github.com/user-attachments/assets/b67a2b5d-8929-437c-886a-cee2245a2fa9


