### PR TITLE
fix: prevent crash by forbidding launch of non-PDF generic files

### DIFF
--- a/js/screens/journal.js
+++ b/js/screens/journal.js
@@ -744,8 +744,8 @@ const Journal = {
 							this.journalId
 						);
 					sugarizer.modules.file.openAsDocument(metadata, text, entry.objectId);
-					return;
 				}
+				return;
 			}
 			// Load text content
 			const { metadata, text } =


### PR DESCRIPTION
fixes ; #2127 

https://github.com/user-attachments/assets/57fc370e-316a-4ede-8fc3-f8b532a465e8

