### PR TITLE
fixed text editor spacing issues

### DIFF
--- a/activities/Write.activity/js/activity.js
+++ b/activities/Write.activity/js/activity.js
@@ -381,7 +381,7 @@ define([
 		document.getElementById("19").addEventListener('click',function(){
 			var title = document.getElementById("title").value;
 			var mimetype = 'text/plain';
-			var inputData = document.getElementById("editor").textContent;
+			var inputData = editor.getText();
 			var metadata = {
 			mimetype: mimetype,
 			title: title+".txt",


### PR DESCRIPTION
Description:
Fixes a bug in the Write activity where exporting to .txt stripped all line breaks, merging paragraphs into a single unreadable block of text.

Changes made:

Updated the plain text export logic to use the editor's native text extraction  rather than the raw DOM .textContent.
This ensures all line breaks, blocks, and structural spacing are correctly preserved in the downloaded text file.

Fixes: #2125 


https://github.com/user-attachments/assets/bd2af00e-35e2-451a-8dc0-2000a145f84c

