### PR TITLE
Fixing rock making a wall in Foodchain Activity

### DIFF
--- a/activities/FoodChain.activity/playgame.js
+++ b/activities/FoodChain.activity/playgame.js
@@ -151,13 +151,18 @@ enyo.kind({
 
 				// ... while don't intersect with ...
 				function(n, s) {
-					return !n.intersect(s);
+					return !n.intersect(s) && (n.distance(s,true) <=100 || n.distance(s,true) >= 300);
 				},
 
 				// ... other rocks and frog
-				enyo.cloneArray(this.rocks).concat(this.frog)
+				enyo.cloneArray(this.rocks).concat(this.frog),
+
+				// We are trying to spawn a rock
+				true
 			);
-			this.rocks.push(rock);
+			if (rock != null) {
+				this.rocks.push(rock);
+			}
 		}
 
 		// Set randomely flies

--- a/activities/FoodChain.activity/playgame.js
+++ b/activities/FoodChain.activity/playgame.js
@@ -151,7 +151,7 @@ enyo.kind({
 
 				// ... while don't intersect with ...
 				function(n, s) {
-					return !n.intersect(s) && (n.distance(s,true) <=100 || n.distance(s,true) >= 300);
+					return !n.intersect(s) && (n.distance(s,true) <= 100 || n.distance(s,true) >= 300);
 				},
 
 				// ... other rocks and frog

--- a/activities/FoodChain.activity/sprite.js
+++ b/activities/FoodChain.activity/sprite.js
@@ -100,9 +100,11 @@ enyo.kind({
 	},
 	
 	// Compute distance between two sprites
-	distance: function(sprite) {
+	distance: function(sprite, manhattanlike=false) {
 		var dx = sprite.x-this.x;
 		var dy = sprite.y-this.y;
+		if (manhattanlike)
+			return Math.max(dx,dy);
 		var dist = Math.sqrt(dx*dx+dy*dy);
 		
 		return dist;	

--- a/activities/FoodChain.activity/sprite.js
+++ b/activities/FoodChain.activity/sprite.js
@@ -104,7 +104,7 @@ enyo.kind({
 		var dx = sprite.x-this.x;
 		var dy = sprite.y-this.y;
 		if (manhattanlike)
-			return Math.max(dx,dy);
+			return Math.abs(Math.max(dx,dy));
 		var dist = Math.sqrt(dx*dx+dy*dy);
 		
 		return dist;	

--- a/activities/FoodChain.activity/util.js
+++ b/activities/FoodChain.activity/util.js
@@ -82,7 +82,7 @@ FoodChain.createWithCondition = function(create, condition, set, isRock=false) {
 	var conditionValue;
 	var newObject;
 	var time = 0;
-	var limit = isRock ? 12 : 24;
+	var limit = isRock ? 24 : 12;
 	do {
 		conditionValue = true;
 		newObject = create();

--- a/activities/FoodChain.activity/util.js
+++ b/activities/FoodChain.activity/util.js
@@ -78,20 +78,24 @@ FoodChain.sleep = function(delay) {
 };
 
 // Create a object respecting a condition on a set of object
-FoodChain.createWithCondition = function(create, condition, set) {
+FoodChain.createWithCondition = function(create, condition, set, isRock=false) {
 	var conditionValue;
 	var newObject;
 	var time = 0;
+	var limit = isRock ? 12 : 24;
 	do {
 		conditionValue = true;
 		newObject = create();
 		for (var i = 0; conditionValue && i < set.length ; i++) {
 			conditionValue = condition(newObject, set[i]);
-		}
+		}	
 		time++;
-	} while (!conditionValue && time < 12); // time to avoid infinite or too long loop in very complex situation
+	} while (!conditionValue && time < limit); // time to avoid infinite or too long loop in very complex situation
 	if (!conditionValue)
 		FoodChain.log("WARNING: out of pre-requisite creating "+newObject.id);
+	if (isRock && time >= limit){ // It means we could spawn the object even after 24 attempts, so we give up
+		return null;
+	}
 	return newObject;
 };
 

--- a/activities/FoodChain.activity/util.js
+++ b/activities/FoodChain.activity/util.js
@@ -88,7 +88,7 @@ FoodChain.createWithCondition = function(create, condition, set, isRock=false) {
 		newObject = create();
 		for (var i = 0; conditionValue && i < set.length ; i++) {
 			conditionValue = condition(newObject, set[i]);
-		}	
+		}
 		time++;
 	} while (!conditionValue && time < limit); // time to avoid infinite or too long loop in very complex situation
 	if (!conditionValue)


### PR DESCRIPTION
Fixes #2135

The chance of rocks creating a wall that separates the frog from the rest of the arena is now almost zero. During testing, this only happened once, and it only affected a small portion of the bottom edge rather than the majority of the area.

The reason I still allow rocks to spawn under a certain threshold is to maintain "clumping," rather than simply forcing them to be as spread out as possible.


```javascript
return !n.intersect(s) && (n.distance(s,true) <= 100 || n.distance(s,true) >= 300);
```

If a valid position for a rock cannot be found after 24 attempts, it will not spawn. This means that when trying to spawn more than three rocks, there is a chance the fourth one won't appear.

I calculated the distance between rocks using a modified Manhattan distance (maximum norm). Since the frog cannot move diagonally, a long diagonal Euclidean distance could fall short, the rocks might still be too close for the frog to navigate between them using only four directions.

Please let me know if you would like me to address any shortcomings of this solution (such as rocks occasionally failing to spawn). 
I didn’t implement fixes for those specific issues yet to avoid unnecessarily complicating the code.