### PR TITLE
Fix pointer interaction and hitboxes on high DPI screens

### DIFF
--- a/activities/PhysicsJS.activity/js/activity.js
+++ b/activities/PhysicsJS.activity/js/activity.js
@@ -530,11 +530,12 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env"], functi
 				}
 				var canvas = document.getElementById("viewport").children[0];
 				var zoom = 1.0 / window.devicePixelRatio;
-				canvas.style.zoom = zoom;
 				var useragent = navigator.userAgent.toLowerCase();
-				if (useragent.indexOf('chrome') == -1) {
-					canvas.style.MozTransform = "scale("+zoom+")";
-					canvas.style.MozTransformOrigin = "0 0";
+				if (useragent.indexOf('firefox') != -1) {
+					canvas.style.transform = "scale("+zoom+")";
+					canvas.style.transformOrigin = "0 0";
+				} else {
+					canvas.style.zoom = zoom;
 				}
 				world.wakeUpAll();
 			}

--- a/activities/PhysicsJS.activity/js/activity.js
+++ b/activities/PhysicsJS.activity/js/activity.js
@@ -985,6 +985,31 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env"], functi
 						return;
 					}
 
+					// Special high DPI hitbox logic for deleting elements
+					if (currentType == -1) {
+						var dpr = window.devicePixelRatio;
+						var bodies = world.getBodies();
+						var closestBody = null;
+						var minDist = Infinity;
+						for (var i = 0; i < bodies.length; i++) {
+							var b = bodies[i];
+							if (!b.geometry) continue;
+							var size = (b.geometry.radius || Math.max(b.geometry.width || 0, b.geometry.height || 0) / 2 || 40) * dpr;
+							var dx = Math.abs(b.state.pos.x - pos.x);
+							var dy = Math.abs(b.state.pos.y - pos.y);
+							var m = Math.sqrt(dx * dx + dy * dy);
+							
+							if (dx <= size + 15 && dy <= size + 15 && m < minDist) {
+								minDist = m;
+								closestBody = b;
+							}
+						}
+						if (closestBody) {
+							world.remove(closestBody);
+							return;
+						}
+					}
+
 					// make previously created body dynamic
 					if (createdBody && physicsActive) {
 						createdBody.treatment = "dynamic";

--- a/activities/PhysicsJS.activity/js/activity.js
+++ b/activities/PhysicsJS.activity/js/activity.js
@@ -972,12 +972,39 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env"], functi
 				);
 			}
 
+			function getCorrectedPos(pos) {
+				var canvas = document.getElementById('viewport').children[0];
+				if (!canvas) return pos;
+				var b = 0, c = 0, a = canvas;
+				if (a.offsetParent) {
+					do { 
+						b += a.offsetLeft; 
+						c += a.offsetTop; 
+					} while (a = a.offsetParent);
+				}
+				var r = canvas.getBoundingClientRect();
+				var scrollLeft = window.pageXOffset || document.documentElement.scrollLeft || 0;
+				var scrollTop = window.pageYOffset || document.documentElement.scrollTop || 0;
+				return { 
+					x: (pos.x + b) - (r.left + scrollLeft), 
+					y: (pos.y + c) - (r.top + scrollTop) 
+				};
+			}
+
+			var lastPointerTarget = null;
+			document.addEventListener('mousedown', function(e) { lastPointerTarget = e.target; }, true);
+			document.addEventListener('touchstart', function(e) { lastPointerTarget = e.target; }, true);
+			document.addEventListener('pointerdown', function(e) { lastPointerTarget = e.target; }, true);
+
 			// add some fun interaction
 			var createdBody = null;
 			var createdStart = null;
 			var distance = null;
 			world.on({
 				'interact:poke': function( pos ){
+					var canvas = document.getElementById('viewport').children[0];
+					if (lastPointerTarget !== canvas) return;
+					pos = getCorrectedPos(pos);
 					// Handle pen drawing mode
 					if (currentType == 4) {
 						isDrawing = true;
@@ -987,14 +1014,13 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env"], functi
 
 					// Special high DPI hitbox logic for deleting elements
 					if (currentType == -1) {
-						var dpr = window.devicePixelRatio;
 						var bodies = world.getBodies();
 						var closestBody = null;
 						var minDist = Infinity;
 						for (var i = 0; i < bodies.length; i++) {
 							var b = bodies[i];
 							if (!b.geometry) continue;
-							var size = (b.geometry.radius || Math.max(b.geometry.width || 0, b.geometry.height || 0) / 2 || 40) * dpr;
+							var size = (b.geometry.radius || Math.max(b.geometry.width || 0, b.geometry.height || 0) / 2 || 40);
 							var dx = Math.abs(b.state.pos.x - pos.x);
 							var dy = Math.abs(b.state.pos.y - pos.y);
 							var m = Math.sqrt(dx * dx + dy * dy);
@@ -1021,6 +1047,9 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env"], functi
 					}
 				}
 				,'interact:move': function( pos ){
+					var canvas = document.getElementById('viewport').children[0];
+					if (lastPointerTarget !== canvas) return;
+					pos = getCorrectedPos(pos);
 					// Handle pen drawing
 					if (currentType == 4 && isDrawing && pos.y > toolbarHeight) {
 
@@ -1062,6 +1091,8 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env"], functi
 					}
 				}
 				,'interact:release': function( pos ){
+					var canvas = document.getElementById('viewport').children[0];
+					if (lastPointerTarget !== canvas) return;
 					// Finish pen drawing
 					if (currentType == 4 && isDrawing) {
 						isDrawing = false;
@@ -1081,6 +1112,8 @@ define(["sugar-web/activity/activity","tutorial","l10n","sugar-web/env"], functi
 					createdBody = null;
 				}
 				,'interact:grab': function ( data ) {
+					var canvas = document.getElementById('viewport').children[0];
+					if (lastPointerTarget !== canvas) return;
 					if (currentType == -1) {
 						world.remove(data.body);
 					}


### PR DESCRIPTION

### Description
Fixed inconsistent hit-detection behavior for the "Clear" tool across different screen resolutions.

### Fixes: #2140 

Previously, on high-DPI screens, the visual canvas scaled correctly but the underlying physics hitboxes did not. As a result, users had to click slightly outside of an object to successfully delete it. 

This fix introduces a custom, resolution-aware distance calculation for the Clear tool. Hitboxes are now perfectly aligned with the visual objects, ensuring smooth and precise deletion across all display scalings and object sizes.

### How to Test (Chrome DevTools)
You can verify the fix works perfectly across different screen scalings (DPR 1, 2, and 3) directly in Chrome:

1. Open Chrome DevTools (`F12` or `Ctrl+Shift+I`) and toggle the **Device Toolbar** (`Ctrl+Shift+M`).
2. Click the three vertical dots (⋮) in the top-right corner of the device toolbar and choose **"Add device pixel ratio"**.
3. A new **DPR** dropdown will appear in the top bar next to the screen dimensions.
4. Set the DPR to **1.0, 2.0, and 3.0** and drop an assortment of small and large objects into the scene.
5. Select the Clear tool and verify that clicking directly on the objects (including their edges or corners) deletes them accurately, without needing to click outside the object 


https://github.com/user-attachments/assets/7c9f121f-4ac1-4536-af7b-b4e0f18171be

