### PR TITLE
Fix: Incorrect country labels and flags when coloring neighboring countries

### DIFF
--- a/activities/ColorMyWorld.activity/lib/map.js
+++ b/activities/ColorMyWorld.activity/lib/map.js
@@ -38,9 +38,35 @@ define(["activity/ol","print","util","colormyworld","humane","flag","l10n"],
 						return;
 					}
 
-					if (!clickedFeature) {
-						clickedFeature = target_feature;
+					clickedFeature = target_feature;
+
+					if (!me.tooltipDisplay || me.tooltipDisplay != name) {
+						me.tooltipDisplay = name;
+						humane.timeout = 1000;
+						humane.log(
+							"<img src='./flags/" + (flag[name.replace(/ /g, '_')] || 'world') + ".svg' " +
+							"style='width:auto;height:1.4em;vertical-align:middle;margin-right:8px;'>" +
+							l10n.get(name.replace(/ /g, '_')).replace(/_/g, ' ')
+						);
+						setTimeout(function() { me.tooltipDisplay = null; }, 1000);
 					}
+
+					FOUND = true;
+					return true;
+
+					if (!me.tooltipDisplay || me.tooltipDisplay != name) {
+						me.tooltipDisplay = name;
+						humane.timeout = 1000;
+						humane.log(
+							"<img src='./flags/" + (flag[name.replace(/ /g, '_')] || 'world') + ".svg' " +
+							"style='width:auto;height:1.4em;vertical-align:middle;margin-right:8px;'>" +
+							l10n.get(name.replace(/ /g, '_')).replace(/_/g, ' ')
+						);
+						setTimeout(function() { me.tooltipDisplay = null; }, 1000);
+					}
+
+					FOUND = true;
+					return true;
 
 					if (!me.tooltipDisplay || me.tooltipDisplay != name) {
 						me.tooltipDisplay = name;
@@ -57,7 +83,7 @@ define(["activity/ol","print","util","colormyworld","humane","flag","l10n"],
 					return false;
 
 				}, {
-					hitTolerance: 4
+					hitTolerance: 0
 				});
 
 				if (clickedFeature) {


### PR DESCRIPTION

### Description

This PR fixes an issue in the Color My World activity where incorrect country names and flags were displayed when coloring neighboring countries.

### Cause

The issue occurred because `forEachFeatureAtPixel` processed multiple overlapping features during a single click event, triggering tooltips for multiple countries.

### Fix

* Stopped iteration after the first valid feature using an early return
* Ensured tooltip is displayed only for the selected feature

### Result

Now only the selected country shows its correct name and flag when coloring, even near borders.

### Issue
Closes #2179 


https://github.com/user-attachments/assets/fdbf18a3-a7bb-4874-a353-2b89aaadaa32



