### PR TITLE
Fix Speak.activity Enter key repeat playback

### DIFF
--- a/activities/Speak.activity/js/SpeakActivity.js
+++ b/activities/Speak.activity/js/SpeakActivity.js
@@ -55,9 +55,25 @@ define(["sugar-web/graphics/palette","sugar-web/env","l10n","sugar-web/datastore
 	var speech = null;
 	var sugarSettings = {};
 	var first = true;
+	var enterHeld = false;
+	var enterReplayPending = false;
+
+	function tryReplayHeldEnter() {
+		if (!enterHeld || !enterReplayPending || speech.isPlaying()) {
+			return;
+		}
+
+		enterReplayPending = false;
+		triggerSpeech();
+	}
 
 	function init(){
 		speech = Speech();
+		speech.onDone(function() {
+			window.setTimeout(function() {
+				tryReplayHeldEnter();
+			}, 0);
+		});
 		env.getEnvironment(function(err, environment) {
 			var defaultLanguage = (typeof chrome != 'undefined' && chrome.app && chrome.app.runtime) ? chrome.i18n.getUILanguage() : navigator.language;
 			if (!environment.user) environment.user = { language: defaultLanguage };
@@ -228,32 +244,56 @@ define(["sugar-web/graphics/palette","sugar-web/env","l10n","sugar-web/datastore
 		}
 	}
 
-	document.getElementById('speakText').onmousedown = function(e){
+	function triggerSpeech() {
+		if (speech.isPlaying()) {
+			return false;
+		}
+
 		var language = document.getElementById('speaklang').innerHTML;
 		var text = document.getElementById('userText').value;
-		speech.playVoice(language, text);
+		var started = speech.playVoice(language, text);
+		if (!started) {
+			return false;
+		}
+
+		moveMouth(text);
 		idleTimer();
+		if (document.getElementById('mode').innerHTML == "3") {
+			addToChat();
+		}
+
+		return true;
+	}
+
+	document.getElementById('speakText').onmousedown = function(e){
+		triggerSpeech();
 	}
 
 	document.getElementById('speakText').onmouseup = function(e){
-		var text = document.getElementById('userText').value;
-		moveMouth(text);
-		if(document.getElementById('mode').innerHTML == "3"){
-			addToChat();
+	}
+
+	document.getElementById('userText').onkeydown = function(e) {
+		var key = e.keyCode || e.which;
+		if (key == 13) {
+			e.preventDefault();
+			enterHeld = true;
+			if (speech.isPlaying()) {
+				enterReplayPending = true;
+				return false;
+			}
+			if (e.repeat && !enterReplayPending) {
+				enterReplayPending = true;
+			}
+			triggerSpeech();
+			return false;
 		}
 	}
 
-	document.getElementById('userText').onkeypress = function(e) {
+	document.getElementById('userText').onkeyup = function(e) {
 		var key = e.keyCode || e.which;
 		if (key == 13) {
-			var language = document.getElementById('speaklang').innerHTML;
-			var text = document.getElementById('userText').value;
-			speech.playVoice(language, text);
-			moveMouth(text);
-			idleTimer();
-			if(document.getElementById('mode').innerHTML == "3"){
-				addToChat();
-			}
+			enterHeld = false;
+			enterReplayPending = false;
 		}
 	}
 

--- a/activities/Speak.activity/js/Speech.js
+++ b/activities/Speak.activity/js/Speech.js
@@ -2,6 +2,8 @@ var Speech = (function() {
 
 	var answerFinal = "";
 	var playing = "";
+	var isPlaying = false;
+	var onDone = null;
 
 	function init(settings){
 		//No Initialization as of now.
@@ -88,27 +90,38 @@ var Speech = (function() {
 	}
 
 	function playVoice(language, text) {
-      playing = text;
+		if (isPlaying) {
+			return false;
+		}
 
-			//Adds option when text is spoken
-			var addUserInput = document.createElement("OPTION");
-			addUserInput.setAttribute("value", playing);
-			addUserInput.text = playing;
-			document.getElementById("combo-box").appendChild(addUserInput);
-			document.getElementById("combo-box").value= playing;
+		if (!text || !text.trim()) {
+			return false;
+		}
 
-			speakArray.push(playing); // Adds recent talks to speakArray
+		isPlaying = true;
+		playing = text;
 
-      if(document.getElementById('mode').innerHTML=="2"){
-	    //After the voice is loaded, playSound callback is called
-	    getBotReply(text);
-	    setTimeout(function(){
-			loadVoice(language, playSound);
-		}, 4000);
-  	  }
-  	  else{
+		// Adds option when text is spoken
+		var addUserInput = document.createElement("OPTION");
+		addUserInput.setAttribute("value", playing);
+		addUserInput.text = playing;
+		document.getElementById("combo-box").appendChild(addUserInput);
+		document.getElementById("combo-box").value = playing;
+
+		speakArray.push(playing); // Adds recent talks to speakArray
+
+		if (document.getElementById('mode').innerHTML == "2") {
+			// After the voice is loaded, playSound callback is called
+			getBotReply(text);
+			setTimeout(function() {
 				loadVoice(language, playSound);
-  	  }
+			}, 4000);
+		}
+		else {
+			loadVoice(language, playSound);
+		}
+
+		return true;
     }
 
 
@@ -123,6 +136,10 @@ var Speech = (function() {
 
 		function soundComplete(){
 			document.getElementById('speaking').innerHTML = "0";
+			isPlaying = false;
+			if (onDone) {
+				onDone();
+			}
 		}
 
 		if (!/iPad|iPhone/.test(navigator.userAgent)) {
@@ -133,14 +150,28 @@ var Speech = (function() {
 			var sound = new Audio(myDataUrl);
 			sound.addEventListener("ended", function(){
 				document.getElementById('speaking').innerHTML = "0";
+				isPlaying = false;
+				if (onDone) {
+					onDone();
+				}
 			});
 			sound.play();
 		}
     }
 
+	function getIsPlaying() {
+		return isPlaying;
+	}
+
+	function setOnDone(callback) {
+		onDone = callback;
+	}
+
 	return {
         init: init,
-		playVoice: playVoice
+		playVoice: playVoice,
+		isPlaying: getIsPlaying,
+		onDone: setOnDone
     };
 
 });


### PR DESCRIPTION
## Changes
Holding Enter in Speak.activity could trigger repeated playback while speech was already running. After enough repeats, the activity triggers slow downs, or runs out of memory and breaks. On the Sugarizer apps the user sees a blank screen after running out of memory; on the browser try-it site Chrome/Edge will ask the user to reload the page.

This change makes Enter handling behave more cleanly:
- only one playback runs at a time
- repeated Enter key events do not start overlapping playback
- if Enter is still being held, playback starts again only after the current one finishes

## Reproduce
1. Open Sugarizer
2. Launch Speak.activity
3. Type text in the input box
4. Press and hold Enter
5. Keep holding Enter while playback starts

## Before
- repeated Enter key events could retrigger playback immediately
- playback could overlap or re-enter while already running
- after enough repeats, the activity becomes unstable

Video
[page@31750c6f0a4c96ea1bb7515aea9383a6.webm](https://github.com/user-attachments/assets/2dabb370-45c0-4267-a467-93c7c3e1521e)

While the speech is active the play button is disabled, but it will start playing again when done if the user (my kid) keeps the Enter button pressed.

<img width="1440" height="980" alt="speak-after-hold" src="https://github.com/user-attachments/assets/1a140950-4d20-47be-8736-45ce95b9c08a" />

## Issue context
The linked issue should keep the same concrete impact described here:
- repeated playback can snowball into severe slowdown and memory exhaustion
- in the Sugarizer app this can end as a blank screen
- in browser try-it flows Chrome/Edge may prompt a reload

Closes #2182
