### PR TITLE
Fix axis label swapping across chart types in shared mode

### DIFF
--- a/activities/Chart.activity/js/ChartView.js
+++ b/activities/Chart.activity/js/ChartView.js
@@ -253,11 +253,26 @@ const ChartView = {
 					x: {
 						...this.chartOptions.scales.x,
 						beginAtZero: true,
+						title: {
+							...this.chartOptions.scales.x.title,
+							text: this.pref.labels.y,
+						},
 						grid: {
-							color: (ctx) => (ctx.tick && ctx.tick.value === 0 ? "rgb(50,50,50)" : "rgb(240,240,240)"),
+							color: (ctx) => (
+								ctx.tick && ctx.tick.value === 0
+									? "rgb(50,50,50)"
+									: "rgb(240,240,240)"
+							),
 						},
 					},
-					y: { ...this.chartOptions.scales.y, offset: true },
+					y: {
+						...this.chartOptions.scales.y,
+						offset: true,
+						title: {
+							...this.chartOptions.scales.y.title,
+							text: this.pref.labels.x,
+						},
+					},
 				},
 			};
 		},

--- a/activities/Chart.activity/js/activity.js
+++ b/activities/Chart.activity/js/activity.js
@@ -391,15 +391,6 @@ const app = new Vue({
 			});
 		},
 		setChartType(type) {
-			
-			if ((this.pref.chartType === "bar" && type === "horizontalBar") ||
-				(this.pref.chartType === "horizontalBar" && type === "bar")) {
-				
-				const tempLabel = this.pref.labels.x;
-				this.pref.labels.x = this.pref.labels.y;
-				this.pref.labels.y = tempLabel;
-			}
-		
 			this.executeAndSendAction(Action_Types.UPDATE_CHART_TYPE, {
 				chartType: type,
 			});


### PR DESCRIPTION
## Summary

Fixes an issue where axis labels became swapped across chart types during shared sessions.

## Problem

The application was directly swapping `pref.labels.x` and `pref.labels.y` when switching between vertical and horizontal bar charts.

Since `pref.labels` is part of the shared synchronized state, the modified labels propagated to other users and chart types, causing incorrect axis mappings.

## Root Cause

Axis labels were being mutated inside `setChartType()` instead of being handled at the rendering layer.

This caused:

* reversed labels in other chart types
* inconsistent synchronization across users
* incorrect axis mappings during shared sessions

## Fix

* Removed direct swapping of shared label state from `activity.js`
* Added chart-type-specific axis title mapping inside `ChartView.js`

Horizontal bar charts now visually remap axis labels during rendering without modifying the synchronized shared state.

## Result

* Shared mode synchronization works correctly
* Axis labels remain consistent across users
* Horizontal bar charts still display semantically correct axis titles

Fixes #2184


