### PR TITLE
Fix incorrect country labels and flags when coloring neighboring countries

### DIFF
--- a/activities/ColorMyWorld.activity/lib/map.js
+++ b/activities/ColorMyWorld.activity/lib/map.js
@@ -57,7 +57,7 @@ define(["activity/ol","print","util","colormyworld","humane","flag","l10n"],
 					return false;
 
 				}, {
-					hitTolerance: 4
+					hitTolerance: 0
 				});
 
 				if (clickedFeature) {


### PR DESCRIPTION
## Description

This PR fixes an issue where clicking adjacent countries (for example, India and Bhutan) could display incorrect country labels and flags.

The issue was caused by the click hit tolerance. With `hitTolerance` set to `4`, clicks near country borders could match neighboring features. Reducing it to `0` ensures that only the intended country is selected.

## Changes

- Changed `hitTolerance` from `4` to `0` in `activities/ColorMyWorld.activity/lib/map.js`.

## Testing

- Reproduced the issue by clicking adjacent countries.
- Verified that incorrect neighboring country tooltips no longer appear.
- Confirmed that the intended country's tooltip is displayed correctly.

Fixes #2179